### PR TITLE
feat(chat): restore the Crisp chat widget from the old site

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -73,7 +73,7 @@ enableGitInfo = true
   googleAnalytics = "G-ZRE3WPMMNK"
 
   # Crisp chat widget (same website id the old site used)
-  crispWebsiteId = "94bcc89f-c80d-4cf6-905c-e9758fc922b6"
+  crispWebsiteId = "ce835c94-3c37-4aac-8bbe-88802bca45dd"
 
   # Global CTA Configuration (disabled for now, we'll use shortcodes)
   [params.cta]

--- a/hugo.toml
+++ b/hugo.toml
@@ -73,7 +73,7 @@ enableGitInfo = true
   googleAnalytics = "G-ZRE3WPMMNK"
 
   # Crisp chat widget (same website id the old site used)
-  crispWebsiteId = "ce835c94-3c37-4aac-8bbe-88802bca45dd"
+  crispWebsiteId = "94bcc89f-c80d-4cf6-905c-e9758fc922b6"
 
   # Global CTA Configuration (disabled for now, we'll use shortcodes)
   [params.cta]

--- a/hugo.toml
+++ b/hugo.toml
@@ -72,6 +72,9 @@ enableGitInfo = true
   # Google Analytics 4 (loaded only in production builds)
   googleAnalytics = "G-ZRE3WPMMNK"
 
+  # Crisp chat widget (same website id the old site used)
+  crispWebsiteId = "94bcc89f-c80d-4cf6-905c-e9758fc922b6"
+
   # Global CTA Configuration (disabled for now, we'll use shortcodes)
   [params.cta]
     enable = false

--- a/layouts/partials/custom-head.html
+++ b/layouts/partials/custom-head.html
@@ -1,0 +1,13 @@
+{{- /* Crisp chat widget - enabled by setting params.crispWebsiteId */ -}}
+{{ with .Site.Params.crispWebsiteId }}
+<script type="text/javascript">
+    window.$crisp = [];
+    window.CRISP_WEBSITE_ID = "{{ . }}";
+    (function () {
+        var d = document, s = d.createElement("script");
+        s.src = "https://client.crisp.chat/l.js";
+        s.async = 1;
+        d.getElementsByTagName("head")[0].appendChild(s);
+    })();
+</script>
+{{ end }}


### PR DESCRIPTION
Restores the Crisp chatbox the old meghna-era site had, so visitors can start a conversation directly. The website id was recovered from `.backup/partials-old/head.html` (the old site loaded the exact same Crisp snippet). Wired through the `custom-head.html` hook the base template already supports, gated on `params.crispWebsiteId`.

The CloudFront CSP has been updated (and applied) to allow Crisp's script/websocket/media domains, so the widget works the moment this merges and deploys.

Worth checking before/after merge: that the Crisp workspace for this website id still exists at crisp.chat and notifications reach you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)