### PR TITLE
fix(contact): use contact@autospotting.io (support@ bounces)

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -343,7 +343,7 @@ client_logos:
     "buttons": [
       {
         "text": "Email Us",
-        "url": "mailto:contact@autospotting.io?subject=AutoSpotting%20Question"
+        "url": "mailto:contact@autospotting.io?subject=Question%20about%20AutoSpotting&body=Hi%20AutoSpotting%20team%2C%0D%0A%0D%0AI%20have%20a%20question%20about%20AutoSpotting%3A%0D%0A%0D%0A%0D%0AA%20bit%20about%20my%20setup%20%28optional%2C%20helps%20us%20answer%20faster%29%3A%0D%0A-%20AWS%20region%28s%29%3A%0D%0A-%20Approx.%20number%20of%20instances%20or%20monthly%20EC2%20spend%3A%0D%0A-%20AutoScaling%20groups%20use%3A%20launch%20templates%20%2F%20launch%20configurations%0D%0A%0D%0AThanks%21"
       },
       {
         "text": "Book a Call",

--- a/content/_index.md
+++ b/content/_index.md
@@ -343,7 +343,7 @@ client_logos:
     "buttons": [
       {
         "text": "Email Us",
-        "url": "mailto:contact@autospotting.io?subject=Question%20about%20AutoSpotting&body=Hi%20AutoSpotting%20team%2C%0D%0A%0D%0AI%20have%20a%20question%20about%20AutoSpotting%3A%0D%0A%0D%0A%0D%0AA%20bit%20about%20my%20setup%20%28optional%2C%20helps%20us%20answer%20faster%29%3A%0D%0A-%20AWS%20region%28s%29%3A%0D%0A-%20Approx.%20number%20of%20instances%20or%20monthly%20EC2%20spend%3A%0D%0A-%20AutoScaling%20groups%20use%3A%20launch%20templates%20%2F%20launch%20configurations%0D%0A%0D%0AThanks%21"
+        "url": "mailto:contact@autospotting.io?subject=Question%20about%20AutoSpotting&body=Hi%20AutoSpotting%20team%2C%0D%0A%0D%0AI%20have%20a%20question%20about%20AutoSpotting%3A%0D%0A%0D%0A%0D%0AA%20bit%20about%20my%20setup%20%28optional%2C%20helps%20us%20answer%20faster%29%3A%0D%0A-%20AWS%20region%28s%29%3A%0D%0A-%20Approx.%20number%20of%20instances%20or%20monthly%20EC2%20spend%3A%0D%0A-%20Your%20use%20case%20and%20tech%20stack%20%28e.g.%20API%2C%20backend%2C%20frontend%2C%20batch%20jobs%29%3A%0D%0A%0D%0AThanks%21"
       },
       {
         "text": "Book a Call",

--- a/content/_index.md
+++ b/content/_index.md
@@ -343,7 +343,7 @@ client_logos:
     "buttons": [
       {
         "text": "Email Us",
-        "url": "mailto:support@autospotting.io?subject=AutoSpotting%20Question"
+        "url": "mailto:contact@autospotting.io?subject=AutoSpotting%20Question"
       },
       {
         "text": "Book a Call",

--- a/hugo.toml
+++ b/hugo.toml
@@ -213,7 +213,7 @@ enableGitInfo = true
   # Footer Column 3 Menu
   [[menu.footer_column_3]]
     name = "Contact Us"
-    url = "mailto:contact@autospotting.io"
+    url = "mailto:contact@autospotting.io?subject=AutoSpotting%20inquiry&body=Hi%20AutoSpotting%20team%2C%0D%0A%0D%0AHow%20can%20we%20help%3F%0D%0A%0D%0A%0D%0AThanks%21"
     weight = 1
   [[menu.footer_column_3]]
     name = "Book a Call"

--- a/hugo.toml
+++ b/hugo.toml
@@ -213,7 +213,7 @@ enableGitInfo = true
   # Footer Column 3 Menu
   [[menu.footer_column_3]]
     name = "Contact Us"
-    url = "mailto:support@autospotting.io"
+    url = "mailto:contact@autospotting.io"
     weight = 1
   [[menu.footer_column_3]]
     name = "Book a Call"


### PR DESCRIPTION
The footer "Contact Us" link and the FAQ "Email Us" button pointed at `support@autospotting.io`, which bounces. Both now use the working `contact@autospotting.io`.

Checked the other sites (leanercloud.com, cloudutil.io) — none reference `support@autospotting.io`; they already use their own `contact@` addresses.

**Note:** the Enterprise pricing card still uses `sales@autospotting.io` (a distinct address, left unchanged). If that alias also bounces, say so and I'll switch it too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)