### PR TITLE
fix(seo): resolve Ahrefs issues (duplicate H1s, http links)

### DIFF
--- a/content/blog/leanercloud/2023-01-27-weekly-update.md
+++ b/content/blog/leanercloud/2023-01-27-weekly-update.md
@@ -35,7 +35,7 @@ I'd love to see your feedback on what else y'all want to see in this GUI tool.
 
 For the rest of the week I spent some time improving my web presence, to simplify and clarify it further.
 
-Based on feedback from people I talked a few weeks back, the website was too heavy in information, and then I somehow also broke [autospotting.io](http://autospotting.io/?utm_source=leanercloud.beehiiv.com&utm_medium=referral&utm_campaign=weekly-update-27-jan-2023) through some manual changes and it was down for a couple of days, and I only realized after someone complained about it on Reddit.
+Based on feedback from people I talked a few weeks back, the website was too heavy in information, and then I somehow also broke [autospotting.io](https://autospotting.io/?utm_source=leanercloud.beehiiv.com&utm_medium=referral&utm_campaign=weekly-update-27-jan-2023) through some manual changes and it was down for a couple of days, and I only realized after someone complained about it on Reddit.
 
 So I finally spent on time to fix it and carved out the information on AutoSpotting from [LeanerCloud.com](https://leanercloud.com) and used it to update [AutoSpotting.io](https://autospotting.io).
 

--- a/content/blog/leanercloud/2023-02-17-weekly-update.md
+++ b/content/blog/leanercloud/2023-02-17-weekly-update.md
@@ -33,7 +33,7 @@ In a nutshell, I'm going to keep focusing on building major new features in the 
 
 Ideally the delta between my Commercial version and the Community Edition will be kept to a minimum, but I think it needs to be significant enough to have at least some companies pay for it, so I can have a viable business and keep building things like this going forward.
 
-I'll try to also articulate this on the [AutoSpotting.io](http://AutoSpotting.io?utm_source=leanercloud.beehiiv.com&utm_medium=referral&utm_campaign=weekly-update-17-feb-2023) website and will start using the Github issue tracker for my roadmap for both AutoSpotting Community Edition and the commercial offering.
+I'll try to also articulate this on the [AutoSpotting.io](https://AutoSpotting.io?utm_source=leanercloud.beehiiv.com&utm_medium=referral&utm_campaign=weekly-update-17-feb-2023) website and will start using the Github issue tracker for my roadmap for both AutoSpotting Community Edition and the commercial offering.
 
 ### Instance type data updates
 

--- a/content/blog/leanercloud/2023-03-03-weekly-update.md
+++ b/content/blog/leanercloud/2023-03-03-weekly-update.md
@@ -53,7 +53,7 @@ I'm very excited about this tool and how easy it makes it to adopt Spot with all
 
 ### Website updates
 
-For the rest of the week I've been working on updating the [autospotting.io](http://autospotting.io?utm_source=leanercloud.beehiiv.com&utm_medium=referral&utm_campaign=weekly-update-3-mar-2023) website and the [AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-6uj4pruhgmun6?utm_source=leanercloud.beehiiv.com&utm_medium=referral&utm_campaign=weekly-update-3-mar-2023) copy to mention the Savings Estimator tool as a convenient way to get started with AutoSpotting.
+For the rest of the week I've been working on updating the [autospotting.io](https://autospotting.io?utm_source=leanercloud.beehiiv.com&utm_medium=referral&utm_campaign=weekly-update-3-mar-2023) website and the [AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-6uj4pruhgmun6?utm_source=leanercloud.beehiiv.com&utm_medium=referral&utm_campaign=weekly-update-3-mar-2023) copy to mention the Savings Estimator tool as a convenient way to get started with AutoSpotting.
 
 As part of this I also did a few small changes to my [AWS Marketplace tool](https://github.com/LeanerCloud/aws-marketplace-cli?utm_source=leanercloud.beehiiv.com&utm_medium=referral&utm_campaign=weekly-update-3-mar-2023) I released the other week, which already saved me some time when updating the copy for the AWS Marketplace.
 

--- a/content/blog/leanercloud/2023-05-10-ec2-spot-pricing-thoughts.md
+++ b/content/blog/leanercloud/2023-05-10-ec2-spot-pricing-thoughts.md
@@ -10,8 +10,6 @@ featured_image: "/images/blog/leanercloud/2023-05-10-ec2-spot-pricing-thoughts.p
 draft: false
 ---
 
-# My thoughts on the current state of EC2 Spot pricing
-
 ## And what you can do about it
 
 
@@ -21,7 +19,7 @@ I've recently seen a [post](https://news.ycombinator.com/item?id=35802157&utm_so
 
 ![](/images/blog/leanercloud-content/thoughts-current-state-ec2-spot-pricing/image-2.png)
 
-As someone building AWS cost optimization [tooling](http://autospotting.io/?utm_source=leanercloud.beehiiv.com&utm_medium=referral&utm_campaign=my-thoughts-on-the-current-state-of-ec2-spot-pricing) that makes it easy for people to use Spot instances, I'm pretty familiar with this space so thought I'd share my 2 cents about this current situation and wanted to also offer a few suggestions to Spot users who want to still get the most of Spot instances.
+As someone building AWS cost optimization [tooling](https://autospotting.io/?utm_source=leanercloud.beehiiv.com&utm_medium=referral&utm_campaign=my-thoughts-on-the-current-state-of-ec2-spot-pricing) that makes it easy for people to use Spot instances, I'm pretty familiar with this space so thought I'd share my 2 cents about this current situation and wanted to also offer a few suggestions to Spot users who want to still get the most of Spot instances.
 
 I've also seen this first hand during my tests for the recent AutoSpotting releases, and also asked by AutoSpotting customers as soon as this first became apparent. To be honest I didn't really have an answer for them at the time, but I've been thinking about it and I think I have a few suggestions to make to Spot users who want to get decent Spot savings.
 

--- a/content/blog/leanercloud/2023-07-04-mixed-autoscaling-groups.md
+++ b/content/blog/leanercloud/2023-07-04-mixed-autoscaling-groups.md
@@ -19,7 +19,7 @@ I'm excited to announce that a new version of AutoSpotting is now available.
 
 For some context if you're not familiar with AutoSpotting, it's a tool that makes it easy to adopt Spot instances in existing Autoscaling groups, without requiring configuration changes, by replacing their instances with Spot clones using attach/detach API calls.
 
-For more information about AutoSpotting you can have a look at [AutoSpotting.io](http://AutoSpotting.io?utm_source=leanercloud.beehiiv.com&utm_medium=referral&utm_campaign=new-autospotting-release-adding-support-for-mixed-autoscaling-groups) or check out our Open Source code on [GitHub](https://github.com/LeanerCloud/AutoSpotting?utm_source=leanercloud.beehiiv.com&utm_medium=referral&utm_campaign=new-autospotting-release-adding-support-for-mixed-autoscaling-groups).
+For more information about AutoSpotting you can have a look at [AutoSpotting.io](https://AutoSpotting.io?utm_source=leanercloud.beehiiv.com&utm_medium=referral&utm_campaign=new-autospotting-release-adding-support-for-mixed-autoscaling-groups) or check out our Open Source code on [GitHub](https://github.com/LeanerCloud/AutoSpotting?utm_source=leanercloud.beehiiv.com&utm_medium=referral&utm_campaign=new-autospotting-release-adding-support-for-mixed-autoscaling-groups).
 
 ## What's new?
 

--- a/content/blog/leanercloud/2024-06-01-declined-job-offer.md
+++ b/content/blog/leanercloud/2024-06-01-declined-job-offer.md
@@ -10,8 +10,6 @@ featured_image: "/images/blog/leanercloud/2024-06-01-declined-job-offer.png"
 draft: false
 ---
 
-# Why I just declined a job offer from a billionaire friend
-
 
  June 01, 2024
 


### PR DESCRIPTION
From the Ahrefs Site Audit:
- **Multiple H1 (2 pages)**: removed the redundant body `# Title` H1 (the template already renders the title) from two posts my earlier cleanup missed.
- **HTTPS page links to HTTP (5)**: switched `http://autospotting.io` links to `https://` across 5 blog posts (also removes an http->https redirect hop).

Not changed (by design): the 99 'noindex' pages are our intentional taxonomy noindex; the 15 '3XX redirects' are the legacy /faq, /products, www->apex and .org->.io redirects; the 2 'missing alt' images are the decorative marquee-duplicate logos with a correct empty alt + aria-hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)