### PR TITLE
fix(seo): emit valid JSON-LD (safeJS) and add SoftwareApplication schema

### DIFF
--- a/layouts/partials/schema.html
+++ b/layouts/partials/schema.html
@@ -1,48 +1,46 @@
+{{- /* All JSON-LD is built as maps and piped through jsonify | safeJS.
+       safeJS is required: inside a <script> element html/template applies
+       JavaScript escaping, which double-encodes a plain jsonify string. */ -}}
+{{- $schemaOrg := "https://schema.org" -}}
 {{- if .IsHome -}}
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "Organization",
-  "name": "AutoSpotting",
-  "url": {{ .Site.BaseURL | jsonify }},
-  "logo": {{ "images/logo.png" | absURL | jsonify }},
-  "sameAs": [
-    "https://github.com/AutoSpotting/AutoSpotting"
-  ]
-}
-</script>
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "WebSite",
-  "name": {{ .Site.Title | jsonify }},
-  "url": {{ .Site.BaseURL | jsonify }},
-  "description": {{ .Site.Params.description | jsonify }}
-}
-</script>
+<script type="application/ld+json">{{ (dict
+  "@context" $schemaOrg
+  "@type" "Organization"
+  "name" "AutoSpotting"
+  "url" site.BaseURL
+  "logo" (absURL "images/logo.png")
+  "sameAs" (slice "https://github.com/AutoSpotting/AutoSpotting")
+) | jsonify | safeJS }}</script>
+<script type="application/ld+json">{{ (dict
+  "@context" $schemaOrg
+  "@type" "WebSite"
+  "name" site.Title
+  "url" site.BaseURL
+  "description" site.Params.description
+) | jsonify | safeJS }}</script>
+<script type="application/ld+json">{{ (dict
+  "@context" $schemaOrg
+  "@type" "SoftwareApplication"
+  "name" "AutoSpotting"
+  "applicationCategory" "DeveloperApplication"
+  "operatingSystem" "AWS"
+  "url" site.BaseURL
+  "description" site.Params.description
+  "offers" (dict "@type" "Offer" "description" "Usage-based pricing through the AWS Marketplace (a share of the savings), with a free open-source edition.")
+  "publisher" (dict "@type" "Organization" "name" "AutoSpotting" "url" site.BaseURL)
+) | jsonify | safeJS }}</script>
 {{- else if and .IsPage (eq .Section "blog") -}}
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "BlogPosting",
-  "headline": {{ .Title | jsonify }},
-  "description": {{ .Description | jsonify }},
-  "url": {{ .Permalink | jsonify }},
-  "datePublished": {{ .Date.Format "2006-01-02T15:04:05Z07:00" | jsonify }},
-  "dateModified": {{ .Lastmod.Format "2006-01-02T15:04:05Z07:00" | jsonify }},
-  "author": {
-    "@type": "Person",
-    "name": {{ .Params.author | default .Site.Params.author | jsonify }}
-  },
-  "publisher": {
-    "@type": "Organization",
-    "name": "AutoSpotting",
-    "logo": {
-      "@type": "ImageObject",
-      "url": {{ "images/logo.png" | absURL | jsonify }}
-    }
-  }{{ with .Params.featured_image }},
-  "image": {{ . | absURL | jsonify }}{{ end }}
-}
-</script>
+{{- $post := dict
+  "@context" $schemaOrg
+  "@type" "BlogPosting"
+  "headline" .Title
+  "description" .Description
+  "url" .Permalink
+  "datePublished" (.Date.Format "2006-01-02T15:04:05Z07:00")
+  "dateModified" (.Lastmod.Format "2006-01-02T15:04:05Z07:00")
+  "author" (dict "@type" "Person" "name" (.Params.author | default site.Params.author))
+  "publisher" (dict "@type" "Organization" "name" "AutoSpotting" "logo" (dict "@type" "ImageObject" "url" (absURL "images/logo.png")))
+}}
+{{- with .Params.featured_image }}{{- $post = merge $post (dict "image" (absURL .)) }}{{- end }}
+<script type="application/ld+json">{{ $post | jsonify | safeJS }}</script>
 {{- end -}}


### PR DESCRIPTION
The homepage and blog JSON-LD were double-encoded: inside a `<script>` element Go's `html/template` JavaScript-escapes the body, so `jsonify` output has to pass through `safeJS`. Without it, Organization / WebSite / BlogPosting rendered as escaped JSON strings rather than objects, so search engines could not parse them.

- Rebuilds every block via `dict | jsonify | safeJS` (valid objects now).
- Adds a `SoftwareApplication` schema for AutoSpotting (product rich-result eligibility).

Verified: valid JSON-LD across home + a blog post. A follow-up can add `FAQPage` once the FAQ PR (#15) lands, sourcing it from a shared data file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured metadata describing the software application, including its category, operating system, offers, and publisher.
  * Expanded and standardized structured metadata for the organization, website, and blog posts.
* **Improvements**
  * Improved consistency and reliability of metadata presented to search engines and other services.
  * Blog post metadata now handles optional images more cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->