### PR TITLE
chore(seo): index only AutoSpotting-related pages

### DIFF
--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -1,6 +1,10 @@
 ---
 title: "Blog"
 description: "News, updates, and insights about AWS cost optimization and AutoSpotting"
+# Only AutoSpotting-related posts are indexed; noindex the blog and override on those posts.
+robots: "noindex, follow"
+cascade:
+  robots: "noindex, follow"
 ---
 
 Stay updated with the latest AutoSpotting releases, AWS cost optimization strategies, and insights from the LeanerCloud team.

--- a/content/blog/leanercloud/2023-04-15-autospotting-release-less-than-week.md
+++ b/content/blog/leanercloud/2023-04-15-autospotting-release-less-than-week.md
@@ -1,4 +1,5 @@
 ---
+robots: "index, follow"
 title: "Another New AutoSpotting Release in Less Than a Week"
 seo_title: "A New AutoSpotting Release in Under a Week"
 date: 2023-04-15T00:00:00+00:00

--- a/content/blog/leanercloud/2023-05-10-ec2-spot-pricing-thoughts.md
+++ b/content/blog/leanercloud/2023-05-10-ec2-spot-pricing-thoughts.md
@@ -1,4 +1,5 @@
 ---
+robots: "index, follow"
 title: "My Thoughts on the Current State of EC2 Spot Pricing"
 seo_title: "The Current State of EC2 Spot Pricing"
 date: 2023-05-10T00:00:00+00:00

--- a/content/blog/leanercloud/2023-05-15-autospotting-comparison-matrix.md
+++ b/content/blog/leanercloud/2023-05-15-autospotting-comparison-matrix.md
@@ -1,4 +1,5 @@
 ---
+robots: "index, follow"
 title: "AutoSpotting Comparison Matrix"
 date: 2023-05-15T00:00:00+00:00
 description: "New comparison matrix showing differences between AutoSpotting editions and standard AWS AutoScaling"

--- a/content/blog/leanercloud/2023-07-04-mixed-autoscaling-groups.md
+++ b/content/blog/leanercloud/2023-07-04-mixed-autoscaling-groups.md
@@ -1,4 +1,5 @@
 ---
+robots: "index, follow"
 title: "New AutoSpotting Release: Mixed Autoscaling Groups Support"
 seo_title: "Mixed AutoScaling Groups Support Released"
 date: 2023-07-04T00:00:00+00:00

--- a/content/blog/leanercloud/2024-04-11-new-autospotting-releases.md
+++ b/content/blog/leanercloud/2024-04-11-new-autospotting-releases.md
@@ -1,4 +1,5 @@
 ---
+robots: "index, follow"
 title: "New AutoSpotting Releases"
 date: 2024-04-11T00:00:00+00:00
 description: "AutoSpotting 1.3.0 with new features and 1.2.3 with critical billing fix"

--- a/content/blog/leanercloud/2024-04-29-bugfix-release-1-3-1.md
+++ b/content/blog/leanercloud/2024-04-29-bugfix-release-1-3-1.md
@@ -1,4 +1,5 @@
 ---
+robots: "index, follow"
 title: "New AutoSpotting Bugfix Release - 1.3.1"
 date: 2024-04-29T00:00:00+00:00
 description: "Critical fixes for Default VPC placement and Lambda timeout issues"

--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -2,8 +2,8 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range .Data.Pages }}
-  {{- /* keep noindexed thin taxonomy pages out of the sitemap */ -}}
-  {{- if not (in (slice "taxonomy" "term") .Kind) }}
+  {{- /* keep noindexed pages (thin taxonomy, and pages with robots noindex) out of the sitemap */ -}}
+  {{- if and (not (in (slice "taxonomy" "term") .Kind)) (not (in (.Params.robots | default "") "noindex")) }}
   <url>
     <loc>{{ strings.TrimSuffix "index.html" .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}


### PR DESCRIPTION
The autospotting.io blog is a Beehiiv import full of off-topic and duplicated content (weekly updates, ec2instances.info/OpenTofu/ONCE posts, Graviton/ECS/Kubernetes, a `cloudutil` monthly-update archive, and a full `leanercloud-backup` copy).

- Noindex the whole blog via a `cascade` on `content/blog/_index.md`.
- Override `robots: index, follow` on the six AutoSpotting-related posts (releases, bugfix 1.3.1, comparison matrix, mixed-ASG support, EC2 Spot pricing).
- Mirror the sitemap fix to exclude any `robots: noindex` page.

Verified: homepage + the 6 posts are `index, follow`; everything else (Graviton, weekly updates, cloudutil, backup) is `noindex`; the sitemap lists exactly those 6 blog URLs plus the homepage. Nothing deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)