### PR TITLE
feat(home): review fixes - softer hero CTA, honest dashboard, working CTA

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -81,10 +81,10 @@ client_logos:
 {{< hero
     headline="Save 60-90% on AWS EC2 Costs"
     sub_headline="AutoSpotting runs Spot inside your existing AutoScaling groups, with automatic failover to on-demand.<br><br>• No re-architecting, no commitments, no lock-in<br>• Add a tag, install in minutes<br>• Runs in your account, no SaaS backend"
-    primary_button_text="Install from AWS Marketplace"
-    primary_button_url="https://aws.amazon.com/marketplace/pp/prodview-6uj4pruhgmun6"
-    secondary_button_text="See Pricing"
-    secondary_button_url="/#pricing"
+    primary_button_text="Estimate your savings"
+    primary_button_url="https://bit.ly/LCSavingsCalculator"
+    secondary_button_text="Install from AWS Marketplace"
+    secondary_button_url="https://aws.amazon.com/marketplace/pp/prodview-6uj4pruhgmun6"
     hero_image="/images/savings-before-after.png"
     hero_image_alt="AWS EC2 costs before and after installing AutoSpotting"
     zoom="true"
@@ -251,14 +251,14 @@ client_logos:
     title="Backed By Expert Support"
     description="Stable, tested binaries delivered through AWS Marketplace. Get setup assistance and long-term support from the team that built AutoSpotting."
     icon="headset"
-    features="Priority support for paying customers,Help with installation and optimization,Regular updates and improvements,Dedicated team with deep AWS expertise"
+    features="Priority support for paying customers,Help with installation and optimization,Regular updates and improvements,Deep AWS expertise from the people who built AutoSpotting"
 >}}
 
 {{< feature
     title="Visual Dashboard & Analytics (Experimental)"
-    description="An experimental web interface to monitor savings, manage AutoScaling groups, and analyze cost optimization in real time. In progress and off by default for now."
+    description="A web interface to monitor savings, manage AutoScaling groups, and estimate optimizations, aiming to make AutoSpotting even easier to run at scale."
     icon="chart"
-    features="Real-time savings tracking,One-click spot enablement for ASGs,Historical cost analysis and reports,Visual savings estimates before enabling"
+    features="In active development,Off by default until it is stable,Not required: AutoSpotting runs fully from tags"
 >}}
 
 {{< /features-section >}}
@@ -383,7 +383,7 @@ client_logos:
         "Based on your AWS footprint",
         "Priority enterprise support",
         "Custom SLAs available",
-        "Dedicated account management",
+        "A dedicated point of contact",
         "Training and onboarding included",
         "Volume discounts",
         "Annual billing options",
@@ -414,11 +414,11 @@ client_logos:
     },
     {
       "question": "Is AutoSpotting production-ready?",
-      "answer": "Yes! AutoSpotting has been battle-tested since 2016 by thousands of companies including major enterprises like Samsung, Expedia, and Mozilla. It includes diversified failover with automatic revert to on-demand instances when spot capacity becomes unavailable."
+      "answer": "Yes. AutoSpotting has been battle-tested since 2016 by thousands of companies including major enterprises like Samsung, Expedia, and Mozilla. It includes diversified failover with automatic revert to on-demand instances when spot capacity becomes unavailable."
     },
     {
       "question": "Do I need to change my infrastructure?",
-      "answer": "No! AutoSpotting works with your existing AutoScaling groups, launch configurations, and launch templates without any changes. Just add the 'spot-enabled=true' tag to your AutoScaling groups."
+      "answer": "No. AutoSpotting works with your existing AutoScaling groups, launch configurations, and launch templates without any changes. Just add the 'spot-enabled=true' tag to your AutoScaling groups."
     },
     {
       "question": "Where does AutoSpotting run?",
@@ -434,7 +434,7 @@ client_logos:
     },
     {
       "question": "Does it work with ECS, EKS, or Elastic Beanstalk?",
-      "answer": "Yes! AutoSpotting works with any service backed by AutoScaling groups, including managed services like ECS, EKS, and Elastic Beanstalk. No special configuration needed."
+      "answer": "Yes. AutoSpotting works with any service backed by AutoScaling groups, including managed services like ECS, EKS, and Elastic Beanstalk. No special configuration needed."
     },
     {
       "question": "Can I use it with load balancers?",

--- a/layouts/shortcodes/cta.html
+++ b/layouts/shortcodes/cta.html
@@ -1,0 +1,26 @@
+{{- /* Local override: the vendored cta shortcode renders through
+       partials/components/cta.html, which reads .Site.Params.cta.* and is gated
+       on .Site.Params.cta.enable (false here), so the shortcode produced nothing.
+       Render inline from the shortcode's own params instead. */ -}}
+{{- $angle := .Get "gradient-angle" | default (.Get "gradient_angle") | default "135" -}}
+{{- $from := .Get "gradient-from" | default (.Get "gradient_from") | default "#065f46" -}}
+{{- $to := .Get "gradient-to" | default (.Get "gradient_to") | default "#0e7490" -}}
+<section class="cta-section">
+  <div class="container">
+    <div class="relative rounded-lg overflow-hidden bg-primary-600 cta-gradient"
+         style="--gradient-angle: {{ $angle }}; --gradient-from: {{ $from }}; --gradient-to: {{ $to }}">
+      <div class="relative text-center max-w-3xl mx-auto px-6 py-10">
+        {{ with .Get "title" }}<h2 class="text-3xl md:text-4xl font-bold text-white mb-6">{{ . }}</h2>{{ end }}
+        {{ with .Get "description" }}<p class="text-xl text-primary-100 mb-8">{{ . }}</p>{{ end }}
+        <div class="flex flex-col sm:flex-row justify-center gap-4">
+          {{ if and (.Get "primary_button_text") (.Get "primary_button_url") }}
+          <a href="{{ .Get "primary_button_url" }}" class="btn bg-white text-primary-600 hover:bg-gray-100">{{ .Get "primary_button_text" }}</a>
+          {{ end }}
+          {{ if and (.Get "secondary_button_text") (.Get "secondary_button_url") }}
+          <a href="{{ .Get "secondary_button_url" }}" class="btn border-2 border-white text-white hover:bg-primary-700">{{ .Get "secondary_button_text" }}</a>
+          {{ end }}
+        </div>
+      </div>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
Addresses the scare-away/consistency review for the technical audience.

- **Hero CTA:** lead with 'Estimate your savings' (the calculator); demote 'Install from AWS Marketplace' to secondary, so a first-time visitor isn't asked to install before understanding the product.
- **Experimental dashboard card:** replace the shipping-sounding feature bullets with honest status (in active development, off by default, not required).
- **FAQ tone:** 'Yes!'/'No!' -> 'Yes.'/'No.'
- **Team language:** 'Dedicated team' -> deep expertise from the people who built AutoSpotting; 'Dedicated account management' -> 'a dedicated point of contact' (consistent with the actual size and with leanercloud.com).
- **Fixes a real bug:** the final CTA never rendered (vendored shortcode gated on disabled `params.cta.enable`); added a local `cta` shortcode so 'Start Saving on AWS Costs Now' now shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)