### PR TITLE
feat(analytics): GA4 conversion tracking on Calendly/Form CTAs

### DIFF
--- a/layouts/partials/custom-head.html
+++ b/layouts/partials/custom-head.html
@@ -26,3 +26,34 @@
     })();
 </script>
 {{ end }}
+
+{{- /* GA4 conversion tracking for outbound CTAs. Fires a generate_lead event
+       when a visitor clicks the signup form or a Book a call (Calendly) link,
+       so these off-site clicks can be counted as conversions. Loaded only in
+       production and only when Google Analytics is configured.
+       In GA4, mark generate_lead as a Key event to count it as a conversion;
+       segment signup vs call by the cta_type event parameter. */ -}}
+{{ if and hugo.IsProduction .Site.Params.googleAnalytics }}
+<script>
+(function () {
+  function ctaType(href) {
+    if (!href) return null;
+    if (href.indexOf("forms.gle") !== -1 || href.indexOf("docs.google.com/forms") !== -1) return "signup_form";
+    if (href.indexOf("calendly.com") !== -1) return "book_call";
+    return null;
+  }
+  document.addEventListener("click", function (e) {
+    var a = e.target && e.target.closest ? e.target.closest("a[href]") : null;
+    if (!a) return;
+    var type = ctaType(a.getAttribute("href"));
+    if (!type || typeof gtag !== "function") return;
+    gtag("event", "generate_lead", {
+      cta_type: type,
+      link_url: a.href,
+      link_text: (a.textContent || "").trim().slice(0, 100),
+      transport_type: "beacon"
+    });
+  }, true);
+})();
+</script>
+{{ end }}


### PR DESCRIPTION
Fires a GA4 `generate_lead` event on clicks to the Book-a-call (Calendly) link (and the signup form if used), with a `cta_type` parameter. Capture-phase delegated listener with beacon transport records off-site clicks GA can't count automatically. Production-gated `custom-head.html`.

**Manual GA4 step:** mark **generate_lead** as a **Key event** in the GA4 console. Note: the AutoSpotting primary CTA is 'Install from AWS Marketplace' (a different domain) which this does not track; if you want Marketplace-click tracking too, say so and I'll add the marketplace host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)