### PR TITLE
docs: soften enterprise SLA and onboarding copy

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -381,9 +381,9 @@ client_logos:
         "Predictable flat monthly fee",
         "Based on your AWS footprint",
         "Priority enterprise support",
-        "Custom SLAs available",
+        "Custom SLAs on request",
         "A dedicated point of contact",
-        "Training and onboarding included",
+        "Onboarding and training available",
         "Volume discounts",
         "Annual billing options",
         "Customizations and whitelabeling available as additional service"


### PR DESCRIPTION
Reframes two Enterprise-tier pricing bullets so they read as negotiable, per-deal offers rather than firm guarantees:

- `Custom SLAs available` -> `Custom SLAs on request`
- `Training and onboarding included` -> `Onboarding and training available` (drops the "included" commitment)

Rationale: the Enterprise tier is a contact-sales custom deal, and these two lines previously read as blanket promises. Softening them keeps the offer honest without removing the capability.

No layout or functional changes; only the pricing-table content in `content/_index.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Enterprise pricing details to clarify that custom SLAs are available on request.
  * Reworded onboarding and training availability information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->