### PR TITLE
seo: foundations - schema, LCP, meta, index blog

### DIFF
--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -1,10 +1,6 @@
 ---
 title: "Blog"
 description: "News, updates, and insights about AWS cost optimization and AutoSpotting"
-# Only AutoSpotting-related posts are indexed; noindex the blog and override on those posts.
-robots: "noindex, follow"
-cascade:
-  robots: "noindex, follow"
 ---
 
 Stay updated with the latest AutoSpotting releases, AWS cost optimization strategies, and insights from the LeanerCloud team.

--- a/hugo.toml
+++ b/hugo.toml
@@ -173,10 +173,10 @@ enableGitInfo = true
     name = "Pricing"
     url = "/#pricing"
     weight = 3
-  # [[menu.main]]
-  # name = "Blog"
-  # url = "/blog/"
-  # weight = 5
+  [[menu.main]]
+    name = "Blog"
+    url = "/blog/"
+    weight = 5
   [[menu.main]]
     name = "FAQ"
     url = "/#faq"
@@ -197,10 +197,10 @@ enableGitInfo = true
     weight = 3
 
   # Footer Column 2 Menu
-  # [[menu.footer_column_2]]
-  # name = "Blog"
-  # url = "/blog/"
-  # weight = 1
+  [[menu.footer_column_2]]
+    name = "Blog"
+    url = "/blog/"
+    weight = 1
   [[menu.footer_column_2]]
     name = "GitHub"
     url = "https://github.com/AutoSpotting/AutoSpotting"

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -29,6 +29,10 @@
     <meta property="og:site_name" content="{{ .Site.Title }}">
     {{ with $socialImage }}
     <meta property="og:image" content="{{ . | absURL }}">
+    {{ if eq . site.Params.image }}
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    {{ end }}
     {{ end }}
     {{ if and .IsPage (eq .Section "blog") }}
     <meta property="article:published_time" content="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">

--- a/layouts/partials/schema.html
+++ b/layouts/partials/schema.html
@@ -2,6 +2,7 @@
        safeJS is required: inside a <script> element html/template applies
        JavaScript escaping, which double-encodes a plain jsonify string. */ -}}
 {{- $schemaOrg := "https://schema.org" -}}
+{{- $marketplaceURL := "https://aws.amazon.com/marketplace/pp/prodview-6uj4pruhgmun6" -}}
 {{- if .IsHome -}}
 <script type="application/ld+json">{{ (dict
   "@context" $schemaOrg
@@ -9,7 +10,7 @@
   "name" "AutoSpotting"
   "url" site.BaseURL
   "logo" (absURL "images/logo.png")
-  "sameAs" (slice "https://github.com/AutoSpotting/AutoSpotting")
+  "sameAs" (slice "https://github.com/AutoSpotting/AutoSpotting" $marketplaceURL)
 ) | jsonify | safeJS }}</script>
 <script type="application/ld+json">{{ (dict
   "@context" $schemaOrg
@@ -18,7 +19,34 @@
   "url" site.BaseURL
   "description" site.Params.description
 ) | jsonify | safeJS }}</script>
-<script type="application/ld+json">{{ (dict
+{{- $reviews := slice }}
+{{- range .Params.testimonials }}
+{{- $reviews = $reviews | append (dict "@type" "Review" "author" (dict "@type" "Person" "name" .name) "reviewBody" .quote) }}
+{{- end }}
+{{- $offers := slice
+  (dict
+    "@type" "Offer"
+    "name" "Community Edition"
+    "price" "0"
+    "priceCurrency" "USD"
+    "description" "Free, open-source (OSL-3.0), self-hosted from source."
+    "url" "https://github.com/AutoSpotting/AutoSpotting"
+  )
+  (dict
+    "@type" "Offer"
+    "name" "Pay as you go"
+    "priceCurrency" "USD"
+    "priceSpecification" (dict
+      "@type" "UnitPriceSpecification"
+      "price" "10"
+      "priceCurrency" "USD"
+      "unitText" "percent of monthly AWS savings generated"
+    )
+    "description" "Usage-based pricing billed through the AWS Marketplace: 10% of the savings AutoSpotting generates on your AWS bill."
+    "url" $marketplaceURL
+  )
+}}
+{{- $app := dict
   "@context" $schemaOrg
   "@type" "SoftwareApplication"
   "name" "AutoSpotting"
@@ -26,9 +54,11 @@
   "operatingSystem" "AWS"
   "url" site.BaseURL
   "description" site.Params.description
-  "offers" (dict "@type" "Offer" "description" "Usage-based pricing through the AWS Marketplace (a share of the savings), with a free open-source edition.")
+  "offers" $offers
   "publisher" (dict "@type" "Organization" "name" "AutoSpotting" "url" site.BaseURL)
-) | jsonify | safeJS }}</script>
+}}
+{{- if gt (len $reviews) 0 }}{{- $app = merge $app (dict "review" $reviews) }}{{- end }}
+<script type="application/ld+json">{{ $app | jsonify | safeJS }}</script>
 {{- with hugo.Data.home_faq }}
 {{- $items := slice }}
 {{- range .questions }}
@@ -50,4 +80,14 @@
 }}
 {{- with .Params.featured_image }}{{- $post = merge $post (dict "image" (absURL .)) }}{{- end }}
 <script type="application/ld+json">{{ $post | jsonify | safeJS }}</script>
+{{- $breadcrumb := dict
+  "@context" $schemaOrg
+  "@type" "BreadcrumbList"
+  "itemListElement" (slice
+    (dict "@type" "ListItem" "position" 1 "name" "Home" "item" site.BaseURL)
+    (dict "@type" "ListItem" "position" 2 "name" "Blog" "item" (absURL "blog/"))
+    (dict "@type" "ListItem" "position" 3 "name" .Title "item" .Permalink)
+  )
+}}
+<script type="application/ld+json">{{ $breadcrumb | jsonify | safeJS }}</script>
 {{- end -}}

--- a/layouts/shortcodes/hero.html
+++ b/layouts/shortcodes/hero.html
@@ -45,14 +45,16 @@
                 <div class="relative z-10">
                     {{ if $zoom }}
                     <button type="button" class="hero-zoom group relative block w-full rounded-xl focus:outline-none focus-visible:ring-4 focus-visible:ring-white/60" aria-label="Enlarge {{ $hero_image_alt }}" data-hero-zoom>
-                        <img src="{{ $hero_image | relURL }}" alt="{{ $hero_image_alt }}" class="rounded-xl shadow-elevation">
+                        {{/* above-the-fold LCP image: intrinsic size prevents layout shift, high priority speeds first paint */}}
+                        <img src="{{ $hero_image | relURL }}" alt="{{ $hero_image_alt }}" width="1713" height="325" fetchpriority="high" class="w-full h-auto rounded-xl shadow-elevation">
                         <span class="absolute bottom-3 right-3 inline-flex items-center gap-1.5 rounded-full bg-white/90 px-3 py-1.5 text-xs font-medium text-gray-700 shadow-md opacity-90 group-hover:opacity-100 transition-opacity" aria-hidden="true">
                             <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="11" cy="11" r="7"/><path stroke-linecap="round" d="M21 21l-4.3-4.3M11 8v6M8 11h6"/></svg>
                             <span class="hidden group-hover:inline">Click to enlarge</span>
                         </span>
                     </button>
                     {{ else }}
-                    <img src="{{ $hero_image | relURL }}" alt="{{ $hero_image_alt }}" class="rounded-xl shadow-elevation">
+                    {{/* above-the-fold LCP image: intrinsic size prevents layout shift, high priority speeds first paint */}}
+                    <img src="{{ $hero_image | relURL }}" alt="{{ $hero_image_alt }}" width="1713" height="325" fetchpriority="high" class="w-full h-auto rounded-xl shadow-elevation">
                     {{ end }}
                 </div>
                 {{ end }}


### PR DESCRIPTION
## What this does

SEO foundations for the AutoSpotting site: richer structured data, a faster hero, complete social meta, and making the blog indexable and reachable. No copy or visual changes on the rendered page.

## Schema / JSON-LD (`layouts/partials/schema.html`)

- **SoftwareApplication pricing**: replaced the text-only Offer with a structured `offers` array: a free Community Edition (`price: "0"`, OSL-3.0) and a "Pay as you go" Offer carrying a `UnitPriceSpecification` for the 10%-of-savings usage fee. Mirrors the pricing table on the home page. The custom Enterprise tier is intentionally left out (no fixed number to publish).
- **Reviews**: added `Review` objects generated from the real named testimonials in `content/_index.md` front matter (author name + their quote). No `ratingValue` or `AggregateRating` is invented, since there are no real star ratings.
- **Organization sameAs**: added the AWS Marketplace listing alongside GitHub. These are the only two profile URLs that actually exist in the repo.
- **BreadcrumbList**: added Home > Blog > Post breadcrumbs on blog single pages.

All JSON-LD keeps the existing `(dict ...) | jsonify | safeJS` pattern and was validated: every rendered block parses as valid JSON.

## LCP / performance (`layouts/shortcodes/hero.html`)

- The hero image is the LCP element. Added intrinsic `width="1713" height="325"` (the image's real pixels) and `fetchpriority="high"`, and kept it responsive with `w-full h-auto`. Same pattern already used in `single.html`. Applied to both the zoom-button and plain variants.

## Social meta (`layouts/_default/baseof.html`)

- Emit `og:image:width`/`og:image:height` (1200x630) only when the social image is the site default `social-card.png`, so a blog post with its own `featured_image` is unaffected. (`twitter:site` was already guarded on `site.Params.twitter`, which is unset, so no tag is emitted.)

## Indexing + reconnecting the blog

- **`content/blog/_index.md`**: removed the blanket `robots: noindex` and its cascade that noindexed the whole blog section. Blog posts now index by default. Taxonomy pages stay noindex via the separate `$isThinTaxonomy` check (untouched). No individual post sets its own noindex, so none are left stranded.
- **`hugo.toml`**: restored the previously commented-out Blog entries in the main nav (weight 5) and footer column 2 (weight 1) so the now-indexable blog is reachable.

## Verification

- `hugo --environment production` builds clean (exit 0).
- Validated the built `index.html` and blog posts: JSON-LD blocks parse as valid JSON with expected `@type`s (Organization, WebSite, SoftwareApplication with offers + review, FAQPage, BlogPosting, BreadcrumbList).
- Blog section index and a previously-noindexed post both now render `robots: index, follow`; taxonomy pages unchanged.
- Hero `<img>`, `og:image:width/height`, and the Blog nav/footer links all render as expected.
