### PR TITLE
seo: reconcile internal links, structured data, image dimensions

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -7,6 +7,8 @@ testimonials:
     company: "Apify"
     company_url: "https://apify.com"
     company_logo: "/images/clients/apify.png"
+    company_logo_width: 376
+    company_logo_height: 91
     avatar: "/images/testimonials/jan-curn.jpg"
     quote: "I think AutoSpotting has by far the best approach to utilizing spot instances that I've seen. With AutoSpotting we're pretty much able to run our whole stateless production workload on spot instances."
   - name: "Andreas Sundström"
@@ -14,6 +16,8 @@ testimonials:
     company: "OhMy"
     company_url: "https://www.ohmy.no"
     company_logo: "/images/clients/ohmy.png"
+    company_logo_width: 206
+    company_logo_height: 96
     avatar: "/images/testimonials/andreas.jpg"
     quote: "Thanks to AutoSpotting we're saving more than 50% of our server costs on AWS"
   - name: "Falko Zurell"
@@ -21,6 +25,8 @@ testimonials:
     company: "HERE Technologies"
     company_url: "https://www.here.com"
     company_logo: "/images/clients/here.png"
+    company_logo_width: 105
+    company_logo_height: 96
     avatar: "/images/testimonials/falko.png"
     quote: "Just deployed my first installation of the AutoSpotting tool… It took only 3 minutes and 5 clicks and now I'm saving 60% of my EC2 cost with Spot instances automagically. Kudos Sir!"
   - name: "Levi McCormick"
@@ -34,6 +40,8 @@ testimonials:
     company: "postale.io"
     company_url: "https://postale.io"
     company_logo: "/images/clients/postale.svg"
+    company_logo_width: 115
+    company_logo_height: 86
     avatar: "/images/testimonials/pierre-alletru.jpg"
     quote: "AutoSpotting is a fantastic service that has exceeded our expectations on what we were looking for: easy conversion to spot, fallback to on-demand, and no lock in. It completely crushes its competitors. Cristian also provided excellent support. Thank you for a job well done!"
   - name: "Jacob Cooper"
@@ -41,41 +49,71 @@ testimonials:
     company: "Flip CX"
     company_url: "https://flipcx.com"
     company_logo: "/images/clients/flipcx.png"
+    company_logo_width: 183
+    company_logo_height: 96
     quote: "This was amazing technical support - thank you!!! I wish I got this from every provider that I worked with, wow."
   - name: "Klas Wikblad"
     title: "CTO, APPRL"
     company: "APPRL"
     company_url: "https://apprl.com"
     company_logo: "/images/clients/apprl.png"
+    company_logo_width: 96
+    company_logo_height: 96
     avatar: "/images/testimonials/klas-wikblad.jpg"
     quote: "AutoSpotting is such a great product, just incredibly smooth and well working. We did not even notice that it was running for several years."
 client_logos:
   - name: "Expedia"
     logo: "/images/clients/expedia.jpg"
+    width: 240
+    height: 96
   - name: "Samsung"
     logo: "/images/clients/samsung.svg"
+    width: 105
+    height: 16
   - name: "Qualcomm"
     logo: "/images/clients/qualcomm.png"
+    width: 251
+    height: 96
   - name: "TED"
     logo: "/images/clients/ted.png"
+    width: 196
+    height: 96
   - name: "Mozilla"
     logo: "/images/clients/mozilla.svg"
+    width: 112
+    height: 32
   - name: "UK Department for Work & Pensions"
     logo: "/images/clients/dwp.png"
+    width: 115
+    height: 96
   - name: "University of Texas"
     logo: "/images/clients/utaustin.png"
+    width: 336
+    height: 96
   - name: "Telefonica"
     logo: "/images/clients/telefonica.png"
+    width: 351
+    height: 96
   - name: "Canal+"
     logo: "/images/clients/canalplus.svg"
+    width: 500
+    height: 125
   - name: "Here Technologies"
     logo: "/images/clients/here.png"
+    width: 105
+    height: 96
   - name: "Apify"
     logo: "/images/clients/apify.png"
+    width: 376
+    height: 91
   - name: "OhMy"
     logo: "/images/clients/ohmy.png"
+    width: 206
+    height: 96
   - name: "Audiomack"
     logo: "/images/clients/audiomack.png"
+    width: 181
+    height: 96
 ---
 
 {{< hero
@@ -97,7 +135,7 @@ client_logos:
   <div class="py-8 px-4 mx-auto max-w-screen-xl lg:py-16 lg:px-6">
     <div class="mx-auto max-w-screen-md text-center">
       <h2 class="mb-4 text-3xl md:text-4xl tracking-tight font-extrabold text-gray-900">Spot instances are 60-90% cheaper. So why isn't everything on Spot?</h2>
-      <p class="mb-4 font-light text-gray-500 sm:text-xl">Because doing it safely by hand is hard. Spot capacity can be reclaimed on a two-minute notice. To handle that safely, you have to diversify across instance types, drain load balancers, and fall back to on-demand when capacity runs out. For the details, see how <a href="/spot-instance-pricing/" class="text-primary-700 hover:underline">AWS Spot instance pricing</a> works.</p>
+      <p class="mb-4 font-light text-gray-500 sm:text-xl">Because doing it safely by hand is hard. Spot capacity can be <a href="/spot-interruption-handling/" class="text-primary-700 hover:underline">reclaimed on a two-minute notice</a>. To handle that safely, you have to diversify across instance types, drain load balancers, and fall back to on-demand when capacity runs out. For the details, see how <a href="/spot-instance-pricing/" class="text-primary-700 hover:underline">AWS Spot instance pricing</a> works.</p>
       <p class="font-light text-gray-500 sm:text-lg">The usual answers each have a catch: the native AWS tooling makes you re-architect every AutoScaling group, commercial Spot managers run your infrastructure through their SaaS, and Reserved Instances or Savings Plans commit your spend for years. AutoSpotting handles all of it from inside your own account, by adding a tag.</p>
     </div>
   </div>
@@ -107,6 +145,7 @@ client_logos:
   <div class="py-8 px-4 mx-auto max-w-screen-xl lg:py-16 lg:px-6">
     <div class="mx-auto max-w-screen-md text-center mb-8 lg:mb-12">
       <h2 class="mb-4 text-3xl md:text-4xl tracking-tight font-extrabold text-gray-900">Three ways to run Spot, and the simplest needs a single tag.</h2>
+      <p class="font-light text-gray-500 sm:text-lg">See the full <a href="/spot-vs-on-demand/" class="text-primary-700 hover:underline">Spot vs on-demand comparison</a> for a deeper look at the cost and reliability trade-offs.</p>
     </div>
     <div class="overflow-x-auto hidden md:block bg-white rounded-xl border border-gray-200 shadow-sm">
       <table class="w-full min-w-[820px] text-left border-collapse text-sm">
@@ -238,6 +277,8 @@ client_logos:
     description="Integrates with ECS, EKS, Elastic Beanstalk, and any service backed by AutoScaling groups. Fits into your existing CI/CD pipelines."
     icon="integration"
     features="Zero vendor lock-in,Easy to suspend or remove anytime,Complements existing AWS services,Multi-account support"
+    buttonText="Spot for Kubernetes & ECS"
+    buttonLink="/spot-for-kubernetes-ecs/"
 >}}
 
 {{< feature

--- a/content/blog/leanercloud/2023-04-15-autospotting-release-less-than-week.md
+++ b/content/blog/leanercloud/2023-04-15-autospotting-release-less-than-week.md
@@ -8,6 +8,8 @@ author: "Cristian Magherusan-Stanciu"
 categories: ["AutoSpotting", "Releases"]
 tags: ["autospotting", "aws", "ecs", "spot-instances", "load-balancer", "leanercloud"]
 featured_image: "/images/blog/leanercloud/weekly-updates.jpg"
+featured_image_width: 1200
+featured_image_height: 781
 draft: false
 ---
 

--- a/content/blog/leanercloud/2023-05-10-ec2-spot-pricing-thoughts.md
+++ b/content/blog/leanercloud/2023-05-10-ec2-spot-pricing-thoughts.md
@@ -8,6 +8,8 @@ author: "Cristian Magherusan-Stanciu"
 categories: ["AWS", "Cost Optimization"]
 tags: ["aws", "ec2", "spot-instances", "pricing", "leanercloud"]
 featured_image: "/images/blog/leanercloud/2023-05-10-ec2-spot-pricing-thoughts.png"
+featured_image_width: 800
+featured_image_height: 374
 draft: false
 ---
 

--- a/content/blog/leanercloud/2023-05-15-autospotting-comparison-matrix.md
+++ b/content/blog/leanercloud/2023-05-15-autospotting-comparison-matrix.md
@@ -7,6 +7,8 @@ author: "Cristian Magherusan-Stanciu"
 categories: ["AutoSpotting", "Documentation"]
 tags: ["autospotting", "aws", "autoscaling", "comparison", "leanercloud"]
 featured_image: "/images/blog/leanercloud/2023-05-15-autospotting-comparison-matrix.png"
+featured_image_width: 276
+featured_image_height: 421
 draft: false
 ---
 

--- a/content/blog/leanercloud/2023-07-04-mixed-autoscaling-groups.md
+++ b/content/blog/leanercloud/2023-07-04-mixed-autoscaling-groups.md
@@ -8,6 +8,8 @@ author: "Cristian Magherusan-Stanciu"
 categories: ["AutoSpotting", "AWS", "Releases"]
 tags: ["autospotting", "aws", "autoscaling", "spot-instances", "leanercloud"]
 featured_image: "/images/blog/leanercloud/2023-07-04-mixed-autoscaling-groups.png"
+featured_image_width: 1292
+featured_image_height: 105
 draft: false
 ---
 

--- a/content/blog/leanercloud/2024-04-11-new-autospotting-releases.md
+++ b/content/blog/leanercloud/2024-04-11-new-autospotting-releases.md
@@ -7,6 +7,8 @@ author: "Cristian Magherusan-Stanciu"
 categories: ["AutoSpotting", "Releases"]
 tags: ["autospotting", "aws", "spot-instances", "releases", "leanercloud"]
 featured_image: "/images/blog/leanercloud/2024-04-11-new-autospotting-releases.png"
+featured_image_width: 276
+featured_image_height: 238
 draft: false
 ---
 

--- a/content/blog/leanercloud/2024-04-29-bugfix-release-1-3-1.md
+++ b/content/blog/leanercloud/2024-04-29-bugfix-release-1-3-1.md
@@ -7,6 +7,8 @@ author: "Cristian Magherusan-Stanciu"
 categories: ["AutoSpotting", "Releases"]
 tags: ["autospotting", "aws", "bugfix", "releases", "leanercloud"]
 featured_image: "/images/blog/leanercloud/2024-04-29-bugfix-release-1-3-1.jpg"
+featured_image_width: 1292
+featured_image_height: 863
 draft: false
 ---
 

--- a/content/spot-for-kubernetes-ecs.md
+++ b/content/spot-for-kubernetes-ecs.md
@@ -3,6 +3,7 @@ title: "Spot for Kubernetes and ECS"
 seo_title: "Running Spot Instances on Kubernetes (EKS) and ECS in AWS"
 description: "Run EC2 Spot on EKS, Kubernetes, and ECS with AutoSpotting. Works with any AutoScaling-backed service, with on-demand failover and no launch-template rewrite."
 layout: "landing"
+faq_data: "spot_kubernetes_ecs_faq"
 url: "/spot-for-kubernetes-ecs/"
 ---
 
@@ -38,29 +39,7 @@ url: "/spot-for-kubernetes-ecs/"
   </div>
 </section>
 
-{{< faq >}}
-{
-  "title": "Spot for Kubernetes and ECS FAQ",
-  "questions": [
-    {
-      "question": "Does AutoSpotting work with EKS and ECS?",
-      "answer": "Yes. AutoSpotting works with any service backed by an EC2 AutoScaling group, including EKS managed node groups, self-managed Kubernetes node pools, ECS container instances, and Elastic Beanstalk. You add a tag to the group, with no launch-template rewrite."
-    },
-    {
-      "question": "Do I have to change my launch templates or node groups?",
-      "answer": "No. AutoSpotting works with your existing AutoScaling groups as they are, whether they use a launch configuration or a launch template. You do not convert them to a mixed instances policy or maintain per-group instance-type lists. Add the tag and remove it to revert."
-    },
-    {
-      "question": "How does it handle ECS draining when a Spot node is reclaimed?",
-      "answer": "It deregisters the instance from its load balancer target group within about 10 seconds of the Spot termination event and extends the same instance and task draining to ECS, so connections drain during the two-minute window rather than being dropped."
-    },
-    {
-      "question": "How does AutoSpotting compare to Karpenter for Spot?",
-      "answer": "Karpenter provisions nodes directly and can request Spot itself. AutoSpotting operates at the AutoScaling group layer, so it fits when your nodes run on managed or self-managed node groups and you want Spot with automatic on-demand fallback without adopting a different provisioner. The same approach covers ECS and Elastic Beanstalk."
-    }
-  ]
-}
-{{< /faq >}}
+{{< faq data="spot_kubernetes_ecs_faq" />}}
 
 <section class="bg-gray-50">
   <div class="py-8 px-4 mx-auto max-w-screen-md lg:py-12 lg:px-6">

--- a/content/spot-interruption-handling.md
+++ b/content/spot-interruption-handling.md
@@ -3,6 +3,7 @@ title: "Spot Interruption Handling"
 seo_title: "EC2 Spot Interruption Handling: How to Run Spot Safely"
 description: "EC2 Spot interruptions give a two-minute notice, and a higher max price won't stop them. Pick low-interruption types and fail over to on-demand automatically."
 layout: "landing"
+faq_data: "spot_interruption_handling_faq"
 url: "/spot-interruption-handling/"
 ---
 
@@ -39,29 +40,7 @@ url: "/spot-interruption-handling/"
   </div>
 </section>
 
-{{< faq >}}
-{
-  "title": "Spot interruption FAQ",
-  "questions": [
-    {
-      "question": "How much warning do I get before a Spot instance is interrupted?",
-      "answer": "About two minutes. EC2 issues a Spot interruption notice through instance metadata and an EventBridge event, then reclaims the instance roughly two minutes later. That window is enough to drain connections and check-point in-flight work if something acts on the notice."
-    },
-    {
-      "question": "Does setting a higher maximum price prevent interruptions?",
-      "answer": "No. Interruptions are driven by capacity in the specific instance pool, not by your maximum price. A higher price does not stop capacity-based reclamation. Diversifying across instance types and falling back to on-demand are what keep the workload resilient."
-    },
-    {
-      "question": "How do I pick instance types that get interrupted less often?",
-      "answer": "Check the AWS Spot Instance Advisor for the historical interruption frequency of each type and region, and diversify across many compatible pools. AutoSpotting automates this by weighing availability, price, and generation, favoring the most-available recent-generation types."
-    },
-    {
-      "question": "What does AutoSpotting do when an instance is interrupted?",
-      "answer": "It deregisters the instance from its load balancer within about 10 seconds of the termination event so connections drain cleanly, immediately launches replacement Spot instances with diversified on-demand failover behind them, and returns the group to Spot once capacity recovers. ECS instance and task draining is handled the same way."
-    }
-  ]
-}
-{{< /faq >}}
+{{< faq data="spot_interruption_handling_faq" />}}
 
 <section class="bg-gray-50">
   <div class="py-8 px-4 mx-auto max-w-screen-md lg:py-12 lg:px-6">

--- a/content/spot-vs-on-demand.md
+++ b/content/spot-vs-on-demand.md
@@ -3,6 +3,7 @@ title: "Spot vs On-Demand"
 seo_title: "EC2 Spot vs On-Demand: When Each One Makes Sense on AWS"
 description: "EC2 Spot costs 60-90% less than on-demand but can be reclaimed on a two-minute notice. See which workloads fit Spot and how to run it safely with fallback."
 layout: "landing"
+faq_data: "spot_vs_on_demand_faq"
 url: "/spot-vs-on-demand/"
 ---
 
@@ -46,29 +47,7 @@ url: "/spot-vs-on-demand/"
   </div>
 </section>
 
-{{< faq >}}
-{
-  "title": "Spot vs on-demand FAQ",
-  "questions": [
-    {
-      "question": "Is Spot always cheaper than on-demand?",
-      "answer": "Spot is discounted from the on-demand rate for the same instance type, typically by 60-90% for Spot-compatible workloads. The discount varies by region, instance type, and current capacity, but Spot prices are set below on-demand for the same hardware."
-    },
-    {
-      "question": "Does a higher maximum price stop my Spot instance from being interrupted?",
-      "answer": "No. Interruptions are driven by capacity in the specific instance pool, not by your bid. A higher maximum price does not prevent capacity-based reclamation. Diversifying across instance types and falling back to on-demand are the ways to stay resilient."
-    },
-    {
-      "question": "How much can I save by moving a workload to Spot?",
-      "answer": "For Spot-compatible workloads the range is usually 60-90%. Even a relatively small AWS footprint often nets over $1,000 per month. You can estimate your own numbers with the free savings calculator before changing anything."
-    },
-    {
-      "question": "What if Spot capacity runs out?",
-      "answer": "AutoSpotting falls back to on-demand instances when Spot capacity is unavailable across all compatible types, so the AutoScaling group keeps its capacity. It returns to Spot once the market recovers, and you can configure a minimum number of on-demand instances per group."
-    }
-  ]
-}
-{{< /faq >}}
+{{< faq data="spot_vs_on_demand_faq" />}}
 
 <section class="bg-gray-50">
   <div class="py-8 px-4 mx-auto max-w-screen-md lg:py-12 lg:px-6">

--- a/data/spot_interruption_handling_faq.json
+++ b/data/spot_interruption_handling_faq.json
@@ -1,0 +1,21 @@
+{
+  "title": "Spot interruption FAQ",
+  "questions": [
+    {
+      "question": "How much warning do I get before a Spot instance is interrupted?",
+      "answer": "About two minutes. EC2 issues a Spot interruption notice through instance metadata and an EventBridge event, then reclaims the instance roughly two minutes later. That window is enough to drain connections and check-point in-flight work if something acts on the notice."
+    },
+    {
+      "question": "Does setting a higher maximum price prevent interruptions?",
+      "answer": "No. Interruptions are driven by capacity in the specific instance pool, not by your maximum price. A higher price does not stop capacity-based reclamation. Diversifying across instance types and falling back to on-demand are what keep the workload resilient."
+    },
+    {
+      "question": "How do I pick instance types that get interrupted less often?",
+      "answer": "Check the AWS Spot Instance Advisor for the historical interruption frequency of each type and region, and diversify across many compatible pools. AutoSpotting automates this by weighing availability, price, and generation, favoring the most-available recent-generation types."
+    },
+    {
+      "question": "What does AutoSpotting do when an instance is interrupted?",
+      "answer": "It deregisters the instance from its load balancer within about 10 seconds of the termination event so connections drain cleanly, immediately launches replacement Spot instances with diversified on-demand failover behind them, and returns the group to Spot once capacity recovers. ECS instance and task draining is handled the same way."
+    }
+  ]
+}

--- a/data/spot_kubernetes_ecs_faq.json
+++ b/data/spot_kubernetes_ecs_faq.json
@@ -1,0 +1,21 @@
+{
+  "title": "Spot for Kubernetes and ECS FAQ",
+  "questions": [
+    {
+      "question": "Does AutoSpotting work with EKS and ECS?",
+      "answer": "Yes. AutoSpotting works with any service backed by an EC2 AutoScaling group, including EKS managed node groups, self-managed Kubernetes node pools, ECS container instances, and Elastic Beanstalk. You add a tag to the group, with no launch-template rewrite."
+    },
+    {
+      "question": "Do I have to change my launch templates or node groups?",
+      "answer": "No. AutoSpotting works with your existing AutoScaling groups as they are, whether they use a launch configuration or a launch template. You do not convert them to a mixed instances policy or maintain per-group instance-type lists. Add the tag and remove it to revert."
+    },
+    {
+      "question": "How does it handle ECS draining when a Spot node is reclaimed?",
+      "answer": "It deregisters the instance from its load balancer target group within about 10 seconds of the Spot termination event and extends the same instance and task draining to ECS, so connections drain during the two-minute window rather than being dropped."
+    },
+    {
+      "question": "How does AutoSpotting compare to Karpenter for Spot?",
+      "answer": "Karpenter provisions nodes directly and can request Spot itself. AutoSpotting operates at the AutoScaling group layer, so it fits when your nodes run on managed or self-managed node groups and you want Spot with automatic on-demand fallback without adopting a different provisioner. The same approach covers ECS and Elastic Beanstalk."
+    }
+  ]
+}

--- a/data/spot_vs_on_demand_faq.json
+++ b/data/spot_vs_on_demand_faq.json
@@ -1,0 +1,21 @@
+{
+  "title": "Spot vs on-demand FAQ",
+  "questions": [
+    {
+      "question": "Is Spot always cheaper than on-demand?",
+      "answer": "Spot is discounted from the on-demand rate for the same instance type, typically by 60-90% for Spot-compatible workloads. The discount varies by region, instance type, and current capacity, but Spot prices are set below on-demand for the same hardware."
+    },
+    {
+      "question": "Does a higher maximum price stop my Spot instance from being interrupted?",
+      "answer": "No. Interruptions are driven by capacity in the specific instance pool, not by your bid. A higher maximum price does not prevent capacity-based reclamation. Diversifying across instance types and falling back to on-demand are the ways to stay resilient."
+    },
+    {
+      "question": "How much can I save by moving a workload to Spot?",
+      "answer": "For Spot-compatible workloads the range is usually 60-90%. Even a relatively small AWS footprint often nets over $1,000 per month. You can estimate your own numbers with the free savings calculator before changing anything."
+    },
+    {
+      "question": "What if Spot capacity runs out?",
+      "answer": "AutoSpotting falls back to on-demand instances when Spot capacity is unavailable across all compatible types, so the AutoScaling group keeps its capacity. It returns to Spot once the market recovers, and you can configure a minimum number of on-demand instances per group."
+    }
+  ]
+}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -28,7 +28,9 @@
                          alt="{{ $.Title }}"
                          class="w-full h-auto rounded-lg"
                          loading="eager"
-                         fetchpriority="high">
+                         fetchpriority="high"
+                         width="{{ $.Params.featured_image_width }}"
+                         height="{{ $.Params.featured_image_height }}">
                 </div>
             {{ end }}
 

--- a/layouts/partials/post-card.html
+++ b/layouts/partials/post-card.html
@@ -1,11 +1,13 @@
 <article class="bg-white rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow duration-300">
     {{ with .Params.featured_image }}
         <a href="{{ $.RelPermalink }}" class="block aspect-w-16 aspect-h-9 overflow-hidden">
-            <img 
-                src="{{ . }}" 
-                alt="{{ $.Title }}" 
+            <img
+                src="{{ . }}"
+                alt="{{ $.Title }}"
                 class="object-cover w-full h-full transform hover:scale-105 transition-transform duration-300"
                 loading="lazy"
+                width="{{ $.Params.featured_image_width }}"
+                height="{{ $.Params.featured_image_height }}"
             >
         </a>
     {{ end }}

--- a/layouts/partials/schema.html
+++ b/layouts/partials/schema.html
@@ -90,12 +90,22 @@
   )
 }}
 <script type="application/ld+json">{{ $breadcrumb | jsonify | safeJS }}</script>
-{{- else if .Params.faq_data -}}
-{{- with (index hugo.Data .Params.faq_data) }}
+{{- else if eq .Layout "landing" -}}
+{{- $page := dict
+  "@context" $schemaOrg
+  "@type" "WebPage"
+  "headline" .Title
+  "description" .Description
+  "url" .Permalink
+}}
+<script type="application/ld+json">{{ $page | jsonify | safeJS }}</script>
+{{- with .Params.faq_data }}
+{{- with (index hugo.Data .) }}
 {{- $items := slice }}
 {{- range .questions }}
 {{- $items = $items | append (dict "@type" "Question" "name" .question "acceptedAnswer" (dict "@type" "Answer" "text" .answer)) }}
 {{- end }}
 <script type="application/ld+json">{{ (dict "@context" $schemaOrg "@type" "FAQPage" "mainEntity" $items) | jsonify | safeJS }}</script>
+{{- end }}
 {{- end }}
 {{- end -}}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -21,15 +21,18 @@
             <div class="space-y-4">
                 {{ $recentCount := .Site.Params.blog.sidebar.recent.count | default 5 }}
                 {{ range first $recentCount (where .Site.RegularPages "Type" "blog") }}
+                    {{ $post := . }}
                     <div class="group">
                         <a href="{{ .RelPermalink }}" class="block">
                             {{ with .Params.featured_image }}
                                 <div class="aspect-w-16 aspect-h-9 mb-3 overflow-hidden rounded-lg">
-                                    <img 
-                                        src="{{ . }}" 
-                                        alt="{{ $.Title }}" 
+                                    <img
+                                        src="{{ . }}"
+                                        alt="{{ $post.Title }}"
                                         class="object-cover w-full h-full transform group-hover:scale-105 transition-transform duration-300"
                                         loading="lazy"
+                                        width="{{ $post.Params.featured_image_width }}"
+                                        height="{{ $post.Params.featured_image_height }}"
                                     >
                                 </div>
                             {{ end }}

--- a/layouts/shortcodes/client-logos.html
+++ b/layouts/shortcodes/client-logos.html
@@ -17,11 +17,11 @@
             <div class="logo-scroll">
                 <div class="logos-slide animate">
                     {{ range .Page.Params.client_logos }}
-                    <img src="{{ .logo | relURL }}" class="h-20" alt="{{ .name }}" loading="lazy" />
+                    <img src="{{ .logo | relURL }}" class="h-20" alt="{{ .name }}" loading="lazy" width="{{ .width }}" height="{{ .height }}" />
                     {{ end }}
                     {{/* duplicated for the seamless marquee loop; hidden from screen readers */}}
                     {{ range .Page.Params.client_logos }}
-                    <img src="{{ .logo | relURL }}" class="h-20" alt="" aria-hidden="true" loading="lazy" />
+                    <img src="{{ .logo | relURL }}" class="h-20" alt="" aria-hidden="true" loading="lazy" width="{{ .width }}" height="{{ .height }}" />
                     {{ end }}
                 </div>
             </div>

--- a/layouts/shortcodes/testimonials.html
+++ b/layouts/shortcodes/testimonials.html
@@ -32,7 +32,7 @@
                             <p class="text-gray-600 mb-2">{{ .title }}</p>
                             {{ if .company_logo }}
                             <a href="{{ .company_url }}" target="_blank" rel="noopener" class="inline-block mt-2">
-                                <img src="{{ .company_logo | relURL }}" alt="{{ .company }}" class="h-8 opacity-70 hover:opacity-100 transition-opacity">
+                                <img src="{{ .company_logo | relURL }}" alt="{{ .company }}" class="h-8 opacity-70 hover:opacity-100 transition-opacity" width="{{ .company_logo_width }}" height="{{ .company_logo_height }}">
                             </a>
                             {{ end }}
                         </div>
@@ -54,7 +54,7 @@
                             <p class="text-gray-600 mb-2">{{ .title }}</p>
                             {{ if .company_logo }}
                             <a href="{{ .company_url }}" target="_blank" rel="noopener" class="inline-block mt-2">
-                                <img src="{{ .company_logo | relURL }}" alt="{{ .company }}" class="h-8 opacity-70 hover:opacity-100 transition-opacity">
+                                <img src="{{ .company_logo | relURL }}" alt="{{ .company }}" class="h-8 opacity-70 hover:opacity-100 transition-opacity" width="{{ .company_logo_width }}" height="{{ .company_logo_height }}">
                             </a>
                             {{ end }}
                         </div>


### PR DESCRIPTION
## Summary
- Link the four Spot content pages from the home page (problem section, comparison section, and the "Works With Your Stack" feature card), completing internal linking that was skipped during the recent content merges to avoid conflicts.
- Add WebPage JSON-LD to the pricing, vs-on-demand, interruption-handling, and Kubernetes/ECS landing pages, and move their inline FAQ shortcodes to data files so they emit FAQPage JSON-LD through the same `faq_data` mechanism the pricing page already uses (no double-emission).
- Add intrinsic width/height to client logos, testimonial company logos, and blog featured images (post cards, sidebar, single-post header) to reduce CLS. Hero images were left untouched, as they already have this.

## Test plan
- [x] `hugo --source . --environment production --destination /tmp/as-recon-build --quiet` exits 0
- [x] All four home-page links resolve to built pages
- [x] JSON-LD on all four landing pages validated as parseable JSON (WebPage + FAQPage, no duplicates)
- [x] Home page and blog post schema unchanged (Organization/WebSite/SoftwareApplication/FAQPage on home; BlogPosting/BreadcrumbList on posts)
- [x] Verified no empty `width=""`/`height=""` attributes anywhere in the build output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FAQ content for Spot interruptions, Kubernetes and ECS, and Spot versus on-demand pricing.
  * Added related links and a Kubernetes & ECS call-to-action.
  * Added structured FAQ and webpage metadata for improved search visibility.

* **Improvements**
  * Added image dimensions across featured images, client logos, testimonials, and article cards to improve page loading and layout stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->