### PR TITLE
seo(content): add AutoSpotting comparison pages

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -145,7 +145,7 @@ client_logos:
   <div class="py-8 px-4 mx-auto max-w-screen-xl lg:py-16 lg:px-6">
     <div class="mx-auto max-w-screen-md text-center mb-8 lg:mb-12">
       <h2 class="mb-4 text-3xl md:text-4xl tracking-tight font-extrabold text-gray-900">Three ways to run Spot, and the simplest needs a single tag.</h2>
-      <p class="font-light text-gray-500 sm:text-lg">See the full <a href="/spot-vs-on-demand/" class="text-primary-700 hover:underline">Spot vs on-demand comparison</a> for a deeper look at the cost and reliability trade-offs.</p>
+      <p class="font-light text-gray-500 sm:text-lg">See the full <a href="/spot-vs-on-demand/" class="text-primary-700 hover:underline">Spot vs on-demand comparison</a> for a deeper look at the cost and reliability trade-offs, or how AutoSpotting compares to <a href="/autospotting-vs-native-asg-spot/" class="text-primary-700 hover:underline">native ASG Spot</a>.</p>
     </div>
     <div class="overflow-x-auto hidden md:block bg-white rounded-xl border border-gray-200 shadow-sm">
       <table class="w-full min-w-[820px] text-left border-collapse text-sm">

--- a/content/autospotting-vs-karpenter.md
+++ b/content/autospotting-vs-karpenter.md
@@ -1,0 +1,145 @@
+---
+title: "AutoSpotting vs Karpenter"
+seo_title: "AutoSpotting vs Karpenter for EC2 Spot on Kubernetes"
+description: "Karpenter provisions Kubernetes nodes and can request Spot. AutoSpotting works at the AutoScaling-group layer with on-demand fallback. See where each fits."
+layout: "landing"
+faq_data: "autospotting_vs_karpenter_faq"
+url: "/autospotting-vs-karpenter/"
+---
+
+{{< hero
+    headline="AutoSpotting vs Karpenter for Spot on Kubernetes"
+    sub_headline="Karpenter is a capable Kubernetes-native node provisioner that can request Spot directly. AutoSpotting works one layer down, at the AutoScaling group.<br><br>They sit at different layers, so this is less about which is better and more about which fits your setup, and when to use both."
+    primary_button_text="Estimate your savings"
+    primary_button_url="https://bit.ly/LCSavingsCalculator"
+    secondary_button_text="Install from AWS Marketplace"
+    secondary_button_url="https://aws.amazon.com/marketplace/pp/prodview-6uj4pruhgmun6"
+    gradient-from="#1e40af"
+    gradient-to="#7c3aed"
+    gradient-angle="135"
+>}}
+
+<section class="bg-white">
+  <div class="py-8 px-4 mx-auto max-w-screen-md lg:py-16 lg:px-6 prose prose-lg">
+    <h2>Different layers, different jobs</h2>
+    <p>Karpenter is an open-source Kubernetes node provisioner. It watches for pending pods and launches right-sized nodes to fit them, it can request Spot capacity directly, and it consolidates nodes as workloads change. If you want a Kubernetes-native provisioner and you are moving off Cluster Autoscaler, Karpenter is a strong, widely used choice.</p>
+    <p>AutoSpotting works one layer down, at the EC2 AutoScaling group. It converts the capacity of groups you already run to Spot, diversifies across compatible instance types, and falls back to on-demand automatically when Spot runs short. It is not a Kubernetes provisioner; it works with any service backed by an AutoScaling group. That includes EKS managed node groups and self-managed Kubernetes node pools, and also ECS, Elastic Beanstalk, and plain AutoScaling groups. So the comparison is not really either-or: the two operate at different layers and often suit different parts of the same estate.</p>
+  </div>
+</section>
+
+<section class="bg-gray-50">
+  <div class="py-8 px-4 mx-auto max-w-screen-xl lg:py-16 lg:px-6">
+    <div class="mx-auto max-w-screen-md text-center mb-8 lg:mb-12">
+      <h2 class="mb-4 text-3xl md:text-4xl tracking-tight font-extrabold text-gray-900">Karpenter vs AutoSpotting</h2>
+    </div>
+    <div class="overflow-x-auto hidden md:block bg-white rounded-xl border border-gray-200 shadow-sm">
+      <table class="w-full min-w-[640px] text-left border-collapse text-sm">
+        <thead>
+          <tr>
+            <th class="p-3 border-b border-gray-200 font-medium text-gray-500 align-bottom"></th>
+            <th class="p-3 border-b border-gray-200 font-bold text-gray-900 align-bottom">Karpenter</th>
+            <th class="p-3 border-b-2 border-primary-600 font-bold text-primary-800 align-bottom bg-primary-50 rounded-t-lg">AutoSpotting</th>
+          </tr>
+        </thead>
+        <tbody class="text-gray-600">
+          <tr>
+            <td class="p-3 border-b border-gray-100 font-medium text-gray-900">Scope</td>
+            <td class="p-3 border-b border-gray-100">Kubernetes nodes (EKS, self-managed)</td>
+            <td class="p-3 border-b border-gray-100 bg-primary-50 text-gray-900">Any AutoScaling-group-backed service (EKS, ECS, Beanstalk, plain ASGs)</td>
+          </tr>
+          <tr>
+            <td class="p-3 border-b border-gray-100 font-medium text-gray-900">Adoption</td>
+            <td class="p-3 border-b border-gray-100">Replaces your node provisioner; you define and operate NodePools</td>
+            <td class="p-3 border-b border-gray-100 bg-primary-50 font-semibold text-primary-800">Add a tag to existing groups; no provisioner change</td>
+          </tr>
+          <tr>
+            <td class="p-3 border-b border-gray-100 font-medium text-gray-900">Spot handling</td>
+            <td class="p-3 border-b border-gray-100">Requests Spot capacity directly for pending pods; consolidates nodes</td>
+            <td class="p-3 border-b border-gray-100 bg-primary-50 text-gray-900">Converts existing group capacity to Spot, diversified across compatible types</td>
+          </tr>
+          <tr>
+            <td class="p-3 border-b border-gray-100 font-medium text-gray-900">On-demand fallback</td>
+            <td class="p-3 border-b border-gray-100">Configurable via NodePools and weights</td>
+            <td class="p-3 border-b border-gray-100 bg-primary-50 text-gray-900">Automatic when Spot is exhausted across compatible pools; returns to Spot on recovery</td>
+          </tr>
+          <tr>
+            <td class="p-3 border-b border-gray-100 font-medium text-gray-900">Where it runs</td>
+            <td class="p-3 border-b border-gray-100">In-cluster controller</td>
+            <td class="p-3 border-b border-gray-100 bg-primary-50 font-semibold text-primary-800">Lambda in your AWS account, no SaaS backend</td>
+          </tr>
+          <tr>
+            <td class="p-3 font-medium text-gray-900">Cost</td>
+            <td class="p-3">Open source</td>
+            <td class="p-3 bg-primary-50 rounded-b-lg font-semibold text-primary-800">Open-source core, or 10% of savings for the commercial edition</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="md:hidden space-y-4 max-w-screen-md mx-auto">
+      <div class="bg-white border border-gray-200 rounded-lg p-5">
+        <h3 class="font-bold text-gray-900 mb-3">Karpenter</h3>
+        <dl class="divide-y divide-gray-100 text-sm">
+          <div class="py-2"><dt class="text-gray-500">Scope</dt><dd class="text-gray-800">Kubernetes nodes (EKS, self-managed)</dd></div>
+          <div class="py-2"><dt class="text-gray-500">Adoption</dt><dd class="text-gray-800">Replaces your node provisioner; you define and operate NodePools</dd></div>
+          <div class="py-2"><dt class="text-gray-500">Spot handling</dt><dd class="text-gray-800">Requests Spot capacity directly for pending pods; consolidates nodes</dd></div>
+          <div class="py-2"><dt class="text-gray-500">On-demand fallback</dt><dd class="text-gray-800">Configurable via NodePools and weights</dd></div>
+          <div class="py-2"><dt class="text-gray-500">Where it runs</dt><dd class="text-gray-800">In-cluster controller</dd></div>
+          <div class="py-2"><dt class="text-gray-500">Cost</dt><dd class="text-gray-800">Open source</dd></div>
+        </dl>
+      </div>
+      <div class="border-2 border-primary-600 bg-primary-50 rounded-lg p-5">
+        <h3 class="font-bold text-primary-800 mb-3">AutoSpotting</h3>
+        <dl class="divide-y divide-primary-100 text-sm">
+          <div class="py-2"><dt class="text-gray-500">Scope</dt><dd class="text-gray-900 font-medium">Any AutoScaling-group-backed service (EKS, ECS, Beanstalk, plain ASGs)</dd></div>
+          <div class="py-2"><dt class="text-gray-500">Adoption</dt><dd class="text-primary-800 font-semibold">Add a tag to existing groups; no provisioner change</dd></div>
+          <div class="py-2"><dt class="text-gray-500">Spot handling</dt><dd class="text-gray-900 font-medium">Converts existing group capacity to Spot, diversified across compatible types</dd></div>
+          <div class="py-2"><dt class="text-gray-500">On-demand fallback</dt><dd class="text-gray-900 font-medium">Automatic when Spot is exhausted across compatible pools; returns to Spot on recovery</dd></div>
+          <div class="py-2"><dt class="text-gray-500">Where it runs</dt><dd class="text-primary-800 font-semibold">Lambda in your AWS account, no SaaS backend</dd></div>
+          <div class="py-2"><dt class="text-gray-500">Cost</dt><dd class="text-primary-800 font-semibold">Open-source core, or 10% of savings for the commercial edition</dd></div>
+        </dl>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="bg-white">
+  <div class="py-8 px-4 mx-auto max-w-screen-md lg:py-16 lg:px-6 prose prose-lg">
+    <h2>Where Karpenter fits</h2>
+    <p>Karpenter is the right tool when you want a Kubernetes-native provisioner in charge of your nodes. It shines when you are replacing Cluster Autoscaler, when you want nodes sized and consolidated in response to pending pods, and when your team is ready to define and operate NodePools as part of how the cluster runs. It requests Spot directly, and you can mix Spot and on-demand through NodePool configuration. If Kubernetes is your whole world and you want provisioning to live inside the cluster, Karpenter is a natural home for that.</p>
+    <h2>Where AutoSpotting fits</h2>
+    <p>AutoSpotting is the right tool when you do not want to replace your node provisioner. If your EKS or self-managed clusters run on managed node groups or self-managed AutoScaling groups that you are happy with, AutoSpotting brings Spot to that existing capacity with automatic on-demand fallback, by adding a tag. There is no new provisioning model to adopt and operate.</p>
+    <p>It also fits when Kubernetes is only part of the picture. Because it works at the AutoScaling group layer, the same tag on the same kind of group also covers ECS, Elastic Beanstalk, and plain AutoScaling groups. One team can use one approach for Spot across Kubernetes and non-Kubernetes workloads alike, instead of one tool for clusters and something else for everything else. Everything runs inside your own AWS account, with no SaaS backend and no cross-account access.</p>
+    <h2>A note on reduced capacity</h2>
+    <p>One behavior worth understanding across all of these options is what happens when Spot runs out. EKS managed node groups running Spot, and the native Auto Scaling group Spot integration in general, do not fall back to on-demand once Spot is exhausted across all configured instance types. They launch fewer nodes, so the cluster silently drops to reduced capacity until Spot frees up, often during high-demand periods such as the end-of-year holiday season. AutoSpotting fails over to on-demand automatically at the AutoScaling group layer, so the group keeps full capacity. With Karpenter, on-demand fallback depends on how you configure your NodePools and weights, so it is a setting to get right rather than an automatic default.</p>
+    <h2>Using both</h2>
+    <p>These are not mutually exclusive. Karpenter can run the clusters where you want a native provisioner, while AutoSpotting brings Spot with automatic on-demand fallback to the AutoScaling groups behind your other clusters and your non-Kubernetes services. Pick per workload rather than treating it as a single all-or-nothing decision. For a deeper look at Spot on containers, including ECS draining, see our guide to <a href="/spot-for-kubernetes-ecs/">running Spot on Kubernetes and ECS</a>.</p>
+  </div>
+</section>
+
+{{< faq data="autospotting_vs_karpenter_faq" />}}
+
+<section class="bg-gray-50">
+  <div class="py-8 px-4 mx-auto max-w-screen-md lg:py-12 lg:px-6">
+    <h2 class="mb-4 text-2xl font-bold text-gray-900">Related</h2>
+    <ul class="space-y-2 text-primary-700">
+      <li><a class="hover:underline" href="/spot-for-kubernetes-ecs/">Running Spot on Kubernetes (EKS) and ECS</a></li>
+      <li><a class="hover:underline" href="/autospotting-vs-native-asg-spot/">AutoSpotting vs native AutoScaling group Spot</a></li>
+      <li><a class="hover:underline" href="/autospotting-vs-spot-io/">AutoSpotting vs Spot.io and commercial Spot managers</a></li>
+      <li><a class="hover:underline" href="/spot-vs-on-demand/">Spot vs on-demand: when each one makes sense</a></li>
+      <li><a class="hover:underline" href="/spot-instance-pricing/">How AWS Spot instance pricing works</a></li>
+      <li><a class="hover:underline" href="/#compare">Three ways to run Spot, compared</a></li>
+    </ul>
+  </div>
+</section>
+
+{{< cta
+    title="Bring Spot to your existing node groups"
+    description="Tag the AutoScaling groups behind your clusters and services, and let AutoSpotting handle diversification, draining, and automatic on-demand fallback."
+    primary_button_text="Install from AWS Marketplace"
+    primary_button_url="https://aws.amazon.com/marketplace/pp/prodview-6uj4pruhgmun6"
+    secondary_button_text="Try Community Edition"
+    secondary_button_url="https://github.com/AutoSpotting/AutoSpotting"
+    gradient_from="#2563eb"
+    gradient_to="#7c3aed"
+    gradient_angle="135"
+>}}

--- a/content/autospotting-vs-native-asg-spot.md
+++ b/content/autospotting-vs-native-asg-spot.md
@@ -1,0 +1,146 @@
+---
+title: "AutoSpotting vs Native ASG Spot"
+seo_title: "AutoSpotting vs Native AWS Auto Scaling Group Spot Policy"
+description: "The native AWS Auto Scaling group Spot integration has no on-demand fallback. See how AutoSpotting adds failover, tag-based setup, and org-wide rollout."
+layout: "landing"
+faq_data: "autospotting_vs_native_asg_faq"
+url: "/autospotting-vs-native-asg-spot/"
+---
+
+{{< hero
+    headline="AutoSpotting vs native AutoScaling group Spot"
+    sub_headline="Both run Spot inside EC2 AutoScaling groups. The native mixed instances policy is built into AWS and free; AutoSpotting adds the parts it leaves out.<br><br>The big one: automatic on-demand fallback, so a group keeps full capacity when Spot runs short instead of silently running fewer instances."
+    primary_button_text="Estimate your savings"
+    primary_button_url="https://bit.ly/LCSavingsCalculator"
+    secondary_button_text="Install from AWS Marketplace"
+    secondary_button_url="https://aws.amazon.com/marketplace/pp/prodview-6uj4pruhgmun6"
+    gradient-from="#1e40af"
+    gradient-to="#7c3aed"
+    gradient-angle="135"
+>}}
+
+<section class="bg-white">
+  <div class="py-8 px-4 mx-auto max-w-screen-md lg:py-16 lg:px-6 prose prose-lg">
+    <h2>Two ways to put Spot in an AutoScaling group</h2>
+    <p>AWS Auto Scaling groups can run Spot natively through a mixed instances policy on a launch template. You define the on-demand and Spot split, list the compatible instance types, pick an allocation strategy, and the group launches Spot capacity for you. It is a built-in AWS feature at no extra charge, and for teams that are happy to maintain that configuration per group it works well.</p>
+    <p>AutoSpotting takes a different route to the same goal. You add a tag to an AutoScaling group you already run, and it converts the group's capacity to Spot without any launch-template changes. The reason to reach for it over the native integration comes down to four differences: automatic on-demand fallback, no launch-template rewrite, fleet-wide rollout, and automated instance-type selection.</p>
+  </div>
+</section>
+
+<section class="bg-gray-50">
+  <div class="py-8 px-4 mx-auto max-w-screen-xl lg:py-16 lg:px-6">
+    <div class="mx-auto max-w-screen-md text-center mb-8 lg:mb-12">
+      <h2 class="mb-4 text-3xl md:text-4xl tracking-tight font-extrabold text-gray-900">Native ASG Spot vs AutoSpotting</h2>
+    </div>
+    <div class="overflow-x-auto hidden md:block bg-white rounded-xl border border-gray-200 shadow-sm">
+      <table class="w-full min-w-[640px] text-left border-collapse text-sm">
+        <thead>
+          <tr>
+            <th class="p-3 border-b border-gray-200 font-medium text-gray-500 align-bottom"></th>
+            <th class="p-3 border-b border-gray-200 font-bold text-gray-900 align-bottom">Native ASG Spot</th>
+            <th class="p-3 border-b-2 border-primary-600 font-bold text-primary-800 align-bottom bg-primary-50 rounded-t-lg">AutoSpotting</th>
+          </tr>
+        </thead>
+        <tbody class="text-gray-600">
+          <tr>
+            <td class="p-3 border-b border-gray-100 font-medium text-gray-900">Setup</td>
+            <td class="p-3 border-b border-gray-100">Convert each group to a launch template with a mixed instances policy</td>
+            <td class="p-3 border-b border-gray-100 bg-primary-50 font-semibold text-primary-800">Add a tag, no config changes</td>
+          </tr>
+          <tr>
+            <td class="p-3 border-b border-gray-100 font-medium text-gray-900">Instance-type selection</td>
+            <td class="p-3 border-b border-gray-100">You maintain per-group type lists</td>
+            <td class="p-3 border-b border-gray-100 bg-primary-50 text-gray-900">Automated, based on your existing type</td>
+          </tr>
+          <tr>
+            <td class="p-3 border-b border-gray-100 font-medium text-gray-900">Failover to on-demand</td>
+            <td class="p-3 border-b border-gray-100">No automatic fallback once all configured Spot pools are exhausted; runs reduced capacity</td>
+            <td class="p-3 border-b border-gray-100 bg-primary-50 text-gray-900">Automatic, and back to Spot when it recovers</td>
+          </tr>
+          <tr>
+            <td class="p-3 border-b border-gray-100 font-medium text-gray-900">Rollout at scale</td>
+            <td class="p-3 border-b border-gray-100">Group by group</td>
+            <td class="p-3 border-b border-gray-100 bg-primary-50 text-gray-900">Whole account or AWS Org, opt-out mode</td>
+          </tr>
+          <tr>
+            <td class="p-3 border-b border-gray-100 font-medium text-gray-900">Reverting</td>
+            <td class="p-3 border-b border-gray-100">Edit the group back off the mixed instances policy</td>
+            <td class="p-3 border-b border-gray-100 bg-primary-50 text-gray-900">Remove the tag to revert</td>
+          </tr>
+          <tr>
+            <td class="p-3 font-medium text-gray-900">Cost</td>
+            <td class="p-3">Free, built into AWS</td>
+            <td class="p-3 bg-primary-50 rounded-b-lg font-semibold text-primary-800">Free open source, or 10% of savings for the commercial edition</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="md:hidden space-y-4 max-w-screen-md mx-auto">
+      <div class="bg-white border border-gray-200 rounded-lg p-5">
+        <h3 class="font-bold text-gray-900 mb-3">Native ASG Spot</h3>
+        <dl class="divide-y divide-gray-100 text-sm">
+          <div class="py-2"><dt class="text-gray-500">Setup</dt><dd class="text-gray-800">Convert each group to a launch template with a mixed instances policy</dd></div>
+          <div class="py-2"><dt class="text-gray-500">Instance-type selection</dt><dd class="text-gray-800">You maintain per-group type lists</dd></div>
+          <div class="py-2"><dt class="text-gray-500">Failover to on-demand</dt><dd class="text-gray-800">No automatic fallback once all configured Spot pools are exhausted; runs reduced capacity</dd></div>
+          <div class="py-2"><dt class="text-gray-500">Rollout at scale</dt><dd class="text-gray-800">Group by group</dd></div>
+          <div class="py-2"><dt class="text-gray-500">Reverting</dt><dd class="text-gray-800">Edit the group back off the mixed instances policy</dd></div>
+          <div class="py-2"><dt class="text-gray-500">Cost</dt><dd class="text-gray-800">Free, built into AWS</dd></div>
+        </dl>
+      </div>
+      <div class="border-2 border-primary-600 bg-primary-50 rounded-lg p-5">
+        <h3 class="font-bold text-primary-800 mb-3">AutoSpotting</h3>
+        <dl class="divide-y divide-primary-100 text-sm">
+          <div class="py-2"><dt class="text-gray-500">Setup</dt><dd class="text-primary-800 font-semibold">Add a tag, no config changes</dd></div>
+          <div class="py-2"><dt class="text-gray-500">Instance-type selection</dt><dd class="text-gray-900 font-medium">Automated, based on your existing type</dd></div>
+          <div class="py-2"><dt class="text-gray-500">Failover to on-demand</dt><dd class="text-gray-900 font-medium">Automatic, and back to Spot when it recovers</dd></div>
+          <div class="py-2"><dt class="text-gray-500">Rollout at scale</dt><dd class="text-gray-900 font-medium">Whole account or AWS Org, opt-out mode</dd></div>
+          <div class="py-2"><dt class="text-gray-500">Reverting</dt><dd class="text-gray-900 font-medium">Remove the tag to revert</dd></div>
+          <div class="py-2"><dt class="text-gray-500">Cost</dt><dd class="text-primary-800 font-semibold">Free open source, or 10% of savings for the commercial edition</dd></div>
+        </dl>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="bg-white">
+  <div class="py-8 px-4 mx-auto max-w-screen-md lg:py-16 lg:px-6 prose prose-lg">
+    <h2>The difference that bites at the worst time: on-demand fallback</h2>
+    <p>This is the caveat few teams know about until it hits them. The native mixed instances policy has no automatic fallback to on-demand once Spot is exhausted across all of the instance types you configured. When that happens, the group does not launch on-demand to make up the shortfall. It simply launches fewer instances and runs at reduced capacity until Spot frees up.</p>
+    <p>Spot shortages tend to arrive exactly when you can least afford reduced capacity, such as the end-of-year holiday season, when many workloads peak and Spot pools tighten at the same time. AutoSpotting handles this differently: when Spot capacity runs short across all compatible pools, it launches on-demand instances so the group keeps its full capacity, and it moves back to Spot once the market recovers. You can also configure a minimum number of on-demand instances per group.</p>
+    <h2>No launch-template rewrite</h2>
+    <p>To run Spot natively you convert each group to a launch template with a mixed instances policy. On a large or legacy estate that is real migration work, group by group, with the risk that comes with editing production launch configuration. AutoSpotting reads the configuration you already have and needs no launch-template changes. You add a tag such as <code>spot-enabled=true</code> and it takes over from there.</p>
+    <h2>Fleet-wide, opt-out rollout</h2>
+    <p>Because the native integration is configured per group, adoption is a group-by-group project. AutoSpotting can run in opt-out mode across a whole account or an AWS Organization, so new groups are covered by default and you exclude the ones you want to keep on pure on-demand. That turns Spot adoption from a per-group task into a fleet-wide default.</p>
+    <h2>Automated instance-type selection</h2>
+    <p>The native policy asks you to list compatible instance types for each group and keep those lists current as your workloads and the instance catalog change. AutoSpotting selects compatible types automatically based on the on-demand type the group already runs, and diversifies across them to spread interruption risk, so there is no per-group list to maintain.</p>
+    <h2>When native ASG Spot is enough</h2>
+    <p>None of this makes the native integration a wrong choice. It is free, fully AWS-supported, and a good fit when you have a small number of groups, you are comfortable maintaining launch templates and instance-type lists, and your workloads can tolerate running at reduced capacity during a Spot shortage. AutoSpotting earns its keep when you want automatic on-demand fallback, tag-based setup with no re-architecting, and rollout across a whole fleet. Both keep your compute inside your own AWS account.</p>
+  </div>
+</section>
+
+{{< faq data="autospotting_vs_native_asg_faq" />}}
+
+<section class="bg-gray-50">
+  <div class="py-8 px-4 mx-auto max-w-screen-md lg:py-12 lg:px-6">
+    <h2 class="mb-4 text-2xl font-bold text-gray-900">Related</h2>
+    <ul class="space-y-2 text-primary-700">
+      <li><a class="hover:underline" href="/autospotting-vs-spot-io/">AutoSpotting vs Spot.io and commercial Spot managers</a></li>
+      <li><a class="hover:underline" href="/autospotting-vs-karpenter/">AutoSpotting vs Karpenter for Spot on Kubernetes</a></li>
+      <li><a class="hover:underline" href="/spot-vs-on-demand/">Spot vs on-demand: when each one makes sense</a></li>
+      <li><a class="hover:underline" href="/spot-instance-pricing/">How AWS Spot instance pricing works</a></li>
+      <li><a class="hover:underline" href="/#compare">Three ways to run Spot, compared</a></li>
+    </ul>
+  </div>
+</section>
+
+{{< cta
+    title="Add on-demand fallback to your Spot groups"
+    description="Tag your existing AutoScaling groups and let AutoSpotting run Spot with automatic on-demand fallback, entirely inside your own AWS account."
+    primary_button_text="Install from AWS Marketplace"
+    primary_button_url="https://aws.amazon.com/marketplace/pp/prodview-6uj4pruhgmun6"
+    secondary_button_text="Try Community Edition"
+    secondary_button_url="https://github.com/AutoSpotting/AutoSpotting"
+    gradient_from="#2563eb"
+    gradient_to="#7c3aed"
+    gradient_angle="135"
+>}}

--- a/content/autospotting-vs-spot-io.md
+++ b/content/autospotting-vs-spot-io.md
@@ -1,0 +1,147 @@
+---
+title: "AutoSpotting vs Spot.io"
+seo_title: "AutoSpotting vs Spot.io and Commercial Spot Managers"
+description: "AutoSpotting and commercial Spot managers like Spot.io both automate Spot. Compare the models: your own AWS account and an open-source core, or a SaaS backend."
+layout: "landing"
+faq_data: "autospotting_vs_spot_io_faq"
+url: "/autospotting-vs-spot-io/"
+---
+
+{{< hero
+    headline="AutoSpotting vs commercial Spot managers"
+    sub_headline="Commercial Spot managers such as Spot.io automate Spot well. The real choice between them and AutoSpotting is about architecture and model, not whether Spot gets automated.<br><br>AutoSpotting runs inside your own AWS account, with no SaaS backend, no cross-account access, and an open-source core."
+    primary_button_text="Estimate your savings"
+    primary_button_url="https://bit.ly/LCSavingsCalculator"
+    secondary_button_text="Install from AWS Marketplace"
+    secondary_button_url="https://aws.amazon.com/marketplace/pp/prodview-6uj4pruhgmun6"
+    gradient-from="#1e40af"
+    gradient-to="#7c3aed"
+    gradient-angle="135"
+>}}
+
+<section class="bg-white">
+  <div class="py-8 px-4 mx-auto max-w-screen-md lg:py-16 lg:px-6 prose prose-lg">
+    <h2>What a commercial Spot manager does well</h2>
+    <p>Commercial Spot managers such as Spot.io are mature products. They automate the hard parts of running Spot: selecting and diversifying instance types, replacing capacity when it is reclaimed, falling back to on-demand, and presenting a dashboard over your fleet. If your priority is a managed service with a vendor operating the automation for you, that model is a reasonable fit, and we will not pretend otherwise on this page.</p>
+    <p>AutoSpotting automates the same core job, converting AutoScaling group capacity to Spot with on-demand fallback and instance-type diversification. Where the two differ is the deployment model, so the honest comparison is on architecture, ownership, and pricing model rather than on a feature checklist. For current terms and capabilities of any specific vendor, check their own site directly; we do not restate other companies' features or pricing here.</p>
+    <h2>The architectural difference: your account vs a SaaS backend</h2>
+    <p>A commercial SaaS Spot manager runs a backend outside your account and connects to your AWS environment with cross-account access to manage capacity on your behalf. That is how the managed model works, and for some teams the convenience is worth it.</p>
+    <p>AutoSpotting runs entirely inside your own AWS account, as Lambda functions, with no SaaS backend and no cross-account access to grant. Nothing about your infrastructure is transmitted to an external service, and it uses minimal IAM permissions. This is the design AutoSpotting has kept since it was first built in 2015-2016, when its author evaluated an early SaaS Spot manager and preferred not to convert everything to a vendor-specific construct or grant a third party standing access to the account.</p>
+    <h2>Deployment model and lock-in</h2>
+    <p>Commercial managers generally onboard your workloads into their own group constructs. That gives them a consistent surface to manage, and it also means the shape of your setup follows the vendor, which can make leaving harder later. AutoSpotting works from a tag on the AutoScaling groups you already run. There is nothing to migrate into, and removing the tag reverts the group to pure on-demand.</p>
+    <h2>Open-source core and pricing model</h2>
+    <p>The AutoSpotting core has been open source since 2016 and is available as the Community Edition under the OSL-3.0 license, so you can read the code, build it yourself, and run it at no cost. The commercial edition adds tested binaries, support, and the latest enhancements, priced at 10% of the savings it generates on your AWS bill, billed through the AWS Marketplace, with a free tier for small installations. It is usage-based: you pay a share of realized savings rather than a seat or platform fee, and there is no long-term commitment.</p>
+  </div>
+</section>
+
+<section class="bg-gray-50">
+  <div class="py-8 px-4 mx-auto max-w-screen-xl lg:py-16 lg:px-6">
+    <div class="mx-auto max-w-screen-md text-center mb-8 lg:mb-12">
+      <h2 class="mb-4 text-3xl md:text-4xl tracking-tight font-extrabold text-gray-900">Commercial Spot manager vs AutoSpotting</h2>
+      <p class="font-light text-gray-500 sm:text-lg">Compared on model and architecture, the parts that do not change from one release to the next.</p>
+    </div>
+    <div class="overflow-x-auto hidden md:block bg-white rounded-xl border border-gray-200 shadow-sm">
+      <table class="w-full min-w-[640px] text-left border-collapse text-sm">
+        <thead>
+          <tr>
+            <th class="p-3 border-b border-gray-200 font-medium text-gray-500 align-bottom"></th>
+            <th class="p-3 border-b border-gray-200 font-bold text-gray-900 align-bottom">Commercial Spot manager</th>
+            <th class="p-3 border-b-2 border-primary-600 font-bold text-primary-800 align-bottom bg-primary-50 rounded-t-lg">AutoSpotting</th>
+          </tr>
+        </thead>
+        <tbody class="text-gray-600">
+          <tr>
+            <td class="p-3 border-b border-gray-100 font-medium text-gray-900">Setup</td>
+            <td class="p-3 border-b border-gray-100">Onboard to their SaaS, adopt their group constructs</td>
+            <td class="p-3 border-b border-gray-100 bg-primary-50 font-semibold text-primary-800">Add a tag, no config changes</td>
+          </tr>
+          <tr>
+            <td class="p-3 border-b border-gray-100 font-medium text-gray-900">Where it runs, your data</td>
+            <td class="p-3 border-b border-gray-100">Their SaaS, with cross-account access</td>
+            <td class="p-3 border-b border-gray-100 bg-primary-50 font-semibold text-primary-800">Your account, no SaaS backend</td>
+          </tr>
+          <tr>
+            <td class="p-3 border-b border-gray-100 font-medium text-gray-900">Failover to on-demand</td>
+            <td class="p-3 border-b border-gray-100">Yes</td>
+            <td class="p-3 border-b border-gray-100 bg-primary-50 text-gray-900">Automatic, and back to Spot when it recovers</td>
+          </tr>
+          <tr>
+            <td class="p-3 border-b border-gray-100 font-medium text-gray-900">Source model</td>
+            <td class="p-3 border-b border-gray-100">Closed source</td>
+            <td class="p-3 border-b border-gray-100 bg-primary-50 text-gray-900">Open-source core (OSL-3.0)</td>
+          </tr>
+          <tr>
+            <td class="p-3 border-b border-gray-100 font-medium text-gray-900">Lock-in</td>
+            <td class="p-3 border-b border-gray-100">Vendor constructs, harder to leave</td>
+            <td class="p-3 border-b border-gray-100 bg-primary-50 text-gray-900">None; remove the tag to revert</td>
+          </tr>
+          <tr>
+            <td class="p-3 font-medium text-gray-900">Cost</td>
+            <td class="p-3">A share of savings</td>
+            <td class="p-3 bg-primary-50 rounded-b-lg font-semibold text-primary-800">Free open source, or 10% of savings for the commercial edition</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="md:hidden space-y-4 max-w-screen-md mx-auto">
+      <div class="bg-white border border-gray-200 rounded-lg p-5">
+        <h3 class="font-bold text-gray-900 mb-3">Commercial Spot manager</h3>
+        <dl class="divide-y divide-gray-100 text-sm">
+          <div class="py-2"><dt class="text-gray-500">Setup</dt><dd class="text-gray-800">Onboard to their SaaS, adopt their group constructs</dd></div>
+          <div class="py-2"><dt class="text-gray-500">Where it runs, your data</dt><dd class="text-gray-800">Their SaaS, with cross-account access</dd></div>
+          <div class="py-2"><dt class="text-gray-500">Failover to on-demand</dt><dd class="text-gray-800">Yes</dd></div>
+          <div class="py-2"><dt class="text-gray-500">Source model</dt><dd class="text-gray-800">Closed source</dd></div>
+          <div class="py-2"><dt class="text-gray-500">Lock-in</dt><dd class="text-gray-800">Vendor constructs, harder to leave</dd></div>
+          <div class="py-2"><dt class="text-gray-500">Cost</dt><dd class="text-gray-800">A share of savings</dd></div>
+        </dl>
+      </div>
+      <div class="border-2 border-primary-600 bg-primary-50 rounded-lg p-5">
+        <h3 class="font-bold text-primary-800 mb-3">AutoSpotting</h3>
+        <dl class="divide-y divide-primary-100 text-sm">
+          <div class="py-2"><dt class="text-gray-500">Setup</dt><dd class="text-primary-800 font-semibold">Add a tag, no config changes</dd></div>
+          <div class="py-2"><dt class="text-gray-500">Where it runs, your data</dt><dd class="text-primary-800 font-semibold">Your account, no SaaS backend</dd></div>
+          <div class="py-2"><dt class="text-gray-500">Failover to on-demand</dt><dd class="text-gray-900 font-medium">Automatic, and back to Spot when it recovers</dd></div>
+          <div class="py-2"><dt class="text-gray-500">Source model</dt><dd class="text-gray-900 font-medium">Open-source core (OSL-3.0)</dd></div>
+          <div class="py-2"><dt class="text-gray-500">Lock-in</dt><dd class="text-gray-900 font-medium">None; remove the tag to revert</dd></div>
+          <div class="py-2"><dt class="text-gray-500">Cost</dt><dd class="text-primary-800 font-semibold">Free open source, or 10% of savings for the commercial edition</dd></div>
+        </dl>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="bg-white">
+  <div class="py-8 px-4 mx-auto max-w-screen-md lg:py-16 lg:px-6 prose prose-lg">
+    <h2>A note on forks of the open-source core</h2>
+    <p>Because AutoSpotting's core has been open source since 2016, some commercial products trace back to that early codebase. Xosphere, for example, is a commercial fork of the original MIT-licensed AutoSpotting. AutoSpotting is the actively developed original: its architecture moved from the initial cron-based model to an event-based one years ago. If you are evaluating a fork, it is worth confirming which architecture it runs today and comparing that against the current AutoSpotting directly, rather than assuming a shared history means shared behavior.</p>
+    <h2>Which model fits you</h2>
+    <p>If you want a fully managed SaaS and are comfortable with a vendor operating the automation and holding cross-account access, a commercial Spot manager is a reasonable choice, and you should compare its current features and pricing on its own terms. If you want the automation to run inside your own account with no SaaS backend, an open-source core you can inspect, tag-based setup on the groups you already have, and usage-based pricing tied to realized savings, that is what AutoSpotting is built for.</p>
+  </div>
+</section>
+
+{{< faq data="autospotting_vs_spot_io_faq" />}}
+
+<section class="bg-gray-50">
+  <div class="py-8 px-4 mx-auto max-w-screen-md lg:py-12 lg:px-6">
+    <h2 class="mb-4 text-2xl font-bold text-gray-900">Related</h2>
+    <ul class="space-y-2 text-primary-700">
+      <li><a class="hover:underline" href="/autospotting-vs-native-asg-spot/">AutoSpotting vs native AutoScaling group Spot</a></li>
+      <li><a class="hover:underline" href="/autospotting-vs-karpenter/">AutoSpotting vs Karpenter for Spot on Kubernetes</a></li>
+      <li><a class="hover:underline" href="/spot-vs-on-demand/">Spot vs on-demand: when each one makes sense</a></li>
+      <li><a class="hover:underline" href="/spot-instance-pricing/">How AWS Spot instance pricing works</a></li>
+      <li><a class="hover:underline" href="/#compare">Three ways to run Spot, compared</a></li>
+    </ul>
+  </div>
+</section>
+
+{{< cta
+    title="Run Spot in your own account"
+    description="Tag your existing AutoScaling groups and let AutoSpotting handle diversification, draining, and on-demand fallback, with no SaaS backend and no cross-account access."
+    primary_button_text="Install from AWS Marketplace"
+    primary_button_url="https://aws.amazon.com/marketplace/pp/prodview-6uj4pruhgmun6"
+    secondary_button_text="Try Community Edition"
+    secondary_button_url="https://github.com/AutoSpotting/AutoSpotting"
+    gradient_from="#2563eb"
+    gradient_to="#7c3aed"
+    gradient_angle="135"
+>}}

--- a/data/autospotting_vs_karpenter_faq.json
+++ b/data/autospotting_vs_karpenter_faq.json
@@ -1,0 +1,21 @@
+{
+  "title": "AutoSpotting vs Karpenter FAQ",
+  "questions": [
+    {
+      "question": "Are AutoSpotting and Karpenter direct competitors?",
+      "answer": "Not exactly. Karpenter is a Kubernetes-native node provisioner that watches pending pods and launches right-sized nodes, and it can request Spot capacity directly. AutoSpotting works one layer down, at the EC2 AutoScaling group, and converts existing group capacity to Spot with automatic on-demand fallback. They operate at different layers and can suit different situations."
+    },
+    {
+      "question": "When does Karpenter make more sense?",
+      "answer": "Karpenter fits when you want a Kubernetes-native provisioner, you are replacing Cluster Autoscaler, and you want node consolidation and bin-packing driven by pending pods. It replaces your provisioning model, which you then define and operate through NodePools."
+    },
+    {
+      "question": "When does AutoSpotting make more sense?",
+      "answer": "AutoSpotting fits when your nodes run on managed or self-managed node groups you do not want to replace, when you want Spot with automatic on-demand fallback without adopting a new provisioner, and when you also run non-Kubernetes services on AutoScaling groups, such as ECS, Elastic Beanstalk, or plain ASGs, and want one approach across all of them."
+    },
+    {
+      "question": "Can I use both?",
+      "answer": "Yes. Karpenter can manage the Kubernetes clusters where you want a native provisioner, while AutoSpotting brings Spot with on-demand fallback to the AutoScaling groups behind your other clusters and non-Kubernetes services. Choose per workload rather than treating it as a single either-or decision."
+    }
+  ]
+}

--- a/data/autospotting_vs_native_asg_faq.json
+++ b/data/autospotting_vs_native_asg_faq.json
@@ -1,0 +1,21 @@
+{
+  "title": "AutoSpotting vs native ASG Spot FAQ",
+  "questions": [
+    {
+      "question": "Does the native Auto Scaling group Spot integration fall back to on-demand?",
+      "answer": "Not automatically. When Spot capacity runs out across all of the instance types configured in a mixed instances policy, the group launches fewer instances and runs at reduced capacity until Spot frees up. It does not launch on-demand to make up the difference. AutoSpotting fails over to on-demand automatically, then returns to Spot when capacity recovers."
+    },
+    {
+      "question": "Do I have to convert my groups to launch templates to use AutoSpotting?",
+      "answer": "No. The native Spot integration requires a launch template with a mixed instances policy and per-group instance-type lists. AutoSpotting works from a tag on your existing AutoScaling groups, with no launch-template rewrite and no configuration changes to the group."
+    },
+    {
+      "question": "How does instance-type selection differ?",
+      "answer": "With the native integration you maintain the list of compatible instance types for each group. AutoSpotting selects compatible types automatically based on the on-demand type the group already uses, and diversifies across them to spread interruption risk."
+    },
+    {
+      "question": "Is the native AWS Spot integration free?",
+      "answer": "Yes, the native mixed instances policy is a built-in AWS feature at no extra charge. AutoSpotting has a free open-source Community Edition, and a commercial edition priced at 10% of the savings it generates, billed through the AWS Marketplace. The trade-off is the automatic on-demand fallback, tag-based setup, and fleet-wide rollout that the native integration does not provide."
+    }
+  ]
+}

--- a/data/autospotting_vs_spot_io_faq.json
+++ b/data/autospotting_vs_spot_io_faq.json
@@ -1,0 +1,21 @@
+{
+  "title": "AutoSpotting vs commercial Spot managers FAQ",
+  "questions": [
+    {
+      "question": "What is the main architectural difference?",
+      "answer": "Commercial Spot managers such as Spot.io run a SaaS backend that connects to your AWS account with cross-account access and manages capacity from their side. AutoSpotting runs entirely inside your own AWS account as Lambda functions, with no SaaS backend and no cross-account access to grant."
+    },
+    {
+      "question": "Is AutoSpotting open source?",
+      "answer": "The AutoSpotting core has been open source since 2016 and is available as the Community Edition under the OSL-3.0 license. A commercial edition adds tested binaries, support, and the latest enhancements, priced at 10% of the savings it generates."
+    },
+    {
+      "question": "Do I have to adopt vendor-specific group constructs?",
+      "answer": "No. AutoSpotting works from a tag on the AutoScaling groups you already run. You do not migrate your groups into a vendor-specific construct, and you can remove the tag to revert at any time."
+    },
+    {
+      "question": "How is AutoSpotting priced?",
+      "answer": "The Community Edition is free and open source. The commercial edition uses usage-based pricing at 10% of the monthly savings it generates on your AWS bill, billed through the AWS Marketplace, with a free tier for small installations. We do not publish other vendors' pricing here, so compare their current terms directly."
+    }
+  ]
+}


### PR DESCRIPTION
## What

Three high-commercial-intent comparison landing pages to capture "AutoSpotting vs X" and "AutoSpotting alternative" buyer-intent searches, written to be factual and fair.

| Page | URL |
|------|-----|
| AutoSpotting vs native ASG Spot | `/autospotting-vs-native-asg-spot/` |
| AutoSpotting vs Spot.io / commercial Spot managers | `/autospotting-vs-spot-io/` |
| AutoSpotting vs Karpenter | `/autospotting-vs-karpenter/` |

Each page follows the established Spot landing-page pattern: `layout: "landing"`, `hero`/`faq`/`cta` shortcodes, a comparison table modeled on the home `#compare` section (responsive: desktop table + mobile cards), `seo_title`/`description`, single H1, indexable, and `WebPage` + `FAQPage` JSON-LD emitted via `faq_data` + a `data/*.json` file (reuses the existing `schema.html` `layout == "landing"` branch, no schema changes, no double-emit).

## Content angles

- **Native ASG Spot**: automatic on-demand fallback (native has none, silently runs reduced capacity when all configured Spot pools are exhausted), no launch-template rewrite, fleet-wide opt-out rollout, automated instance-type selection. Fair "when native is enough" section.
- **Spot.io / commercial managers**: acknowledges what a SaaS Spot manager does well, then compares on architecture and model only (own AWS account vs SaaS backend + cross-account access, tag-based vs vendor constructs, open-source core, usage-based 10%-of-savings pricing). Does not restate any competitor's features or pricing. Includes a brief, non-disparaging note on open-source forks (Xosphere).
- **Karpenter**: fair "where each fits" framing (Karpenter is a capable Kubernetes-native provisioner that requests Spot directly; AutoSpotting works at the ASG layer with automatic on-demand fallback and also covers non-Kubernetes ASG-backed services). Explicitly not either-or.

## Internal linking

Cross-links the three pages to each other and to `/spot-vs-on-demand/`, `/spot-instance-pricing/`, `/spot-for-kubernetes-ecs/`, and the home `#compare` section. Adds one contextual link from the home comparison section to the native ASG Spot page.

## Verification

- `hugo --environment production` builds clean (exit 0).
- Each page: single H1, `index, follow`, correct pretty canonical URL, `WebPage` + `FAQPage` JSON-LD both valid JSON (4 FAQ Q&A each).
- 0 em-dashes, no banned marketing filler, no competitor feature/pricing invention.
- Comparison tables render with responsive mobile-card fallback (no horizontal body scroll).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comparison guides for AutoSpotting versus Karpenter, native AWS Auto Scaling Spot support, and commercial Spot management platforms.
  * Added responsive comparison tables, setup guidance, fallback behavior, pricing, licensing, suitability, and combined-use recommendations.
  * Added dedicated FAQs for each comparison topic.
  * Added links to the native ASG Spot comparison page and related resources, installation options, savings estimation, and Community Edition information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->